### PR TITLE
Add ability to use states like with Laravel Factories

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -256,6 +256,51 @@ public function customer_has_user()
 }
 ```
 
+### Factory States
+If you have setup any States in your laravel factories, then you can also use them with Poser.
+
+So if in your Laravel customer factory class you have the following states setup
+
+```php
+$factory->state(Customer::class, 'active', function (Faker $faker) {
+    return [
+        'active' => true,
+    ];
+});
+
+$factory->state(Customer::class, 'inactive', function (Faker $faker) {
+    return [
+        'active' => false,
+    ];
+});
+
+``` 
+
+Then you can use the `state` method to tell Poser to also use these factory states
+
+```php
+/** @test */
+public function customer_is_active()
+{
+    $customer = CustomerFactory::new()
+        ->state('active')
+        ->create();
+
+    $this->assertTrue($customer->active);
+}
+```
+
+Like Laravel's Factories, there is also a `states` method to allow you to use multiple states
+
+```php
+$customer = CustomerFactory::new()
+    ->states('state1', 'state2', 'etc')
+    ->create();
+
+```
+
+
+
 ### Factory API
 
 #### ::new()

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -22,7 +22,8 @@ abstract class Factory {
         $count = 1,
         $saveMethodRelationships,
         $belongsToRelationships,
-        $attributes = [];
+        $attributes = [],
+        $states = [];
 
     public static function new()
     {
@@ -198,7 +199,8 @@ abstract class Factory {
 
     public function make($attributes = [])
     {
-        $factory = factory($this->getModelName());
+        $factory = factory($this->getModelName())
+            ->states($this->states);
 
         if ($this->count > 1)
             $factory->times($this->count);
@@ -214,6 +216,22 @@ abstract class Factory {
             return static::$modelName;
 
         return config('poser.models_directory', "App\\") . Str::beforeLast(class_basename($this), "Factory");
+    }
+
+    public function state($state)
+    {
+        $this->states[] = $state;
+
+        return $this;
+    }
+
+    public function states(...$states)
+    {
+        collect($states)->flatten()->each(function($state) {
+           $this->states[] = $state;
+        });
+
+        return $this;
     }
 
 }


### PR DESCRIPTION
This will allow you to use the factory states from the Laravel factories

However, atm, it does not allow for the use of the `afterCreatingState` methods and such.

I believe that this is down to `make` being called on the factory, and then `save` after the before relations are added.

Once fully switched over, this is something that might not be an issue, but it would certainly help me (and I assume others) in the transition

Resolves https://github.com/lukeraymonddowning/poser/issues/1