### PR TITLE
Fix Error: Cannot access property Tests\Factories\UserFactory::$relationshipPrefixes

### DIFF
--- a/src/Factory.php
+++ b/src/Factory.php
@@ -16,7 +16,7 @@ use Lukeraymonddowning\Poser\Exceptions\ArgumentsNotSatisfiableException;
 abstract class Factory {
 
     protected static $modelName = null;
-    private static $relationshipPrefixes = ['with', 'for'];
+    protected static $relationshipPrefixes = ['with', 'for'];
 
     protected
         $count = 1,


### PR DESCRIPTION
As this property was `private` it meant that the factories cannot use it when it is called
(in my case from this line https://github.com/lukeraymonddowning/poser/blob/master/src/Factory.php#L79)

So changing this to `protected` so the factory classes have access to it as well as the core Factory class