### PR TITLE
Make Command Improvements

### DIFF
--- a/src/CreatePoserFactory.php
+++ b/src/CreatePoserFactory.php
@@ -9,7 +9,8 @@ use Illuminate\Support\Facades\File;
 class CreatePoserFactory extends GeneratorCommand
 {
     protected $signature = 'make:poser {name : The name of the Poser Factory}
-                                       {--m|model= : The model that this factory is linked too}';
+                                       {--m|model= : The model that this factory is linked too}
+                                       {--f|factory : Also create the Laravel database factory}';
 
     protected $description = 'Creates a Poser Model Factory with the given name';
 
@@ -88,7 +89,32 @@ class CreatePoserFactory extends GeneratorCommand
         $this->info($name . " successfully created at " . $destination);
         $this->line("");
         $this->line("Remember, you should have a corresponding model, database factory and migration");
+
+        if ($this->option('factory')) {
+            $this->line("");
+            $this->line("Creating database factory");
+
+            $this->createFactory($linkedModelNamespace);
+        }
+
         $this->line("");
         $this->info("Please consider starring the repo at https://github.com/lukeraymonddowning/poser");
+    }
+
+    /**
+     * Create a database factory for the model.
+     *
+     * @param string $modelNamespace
+     *
+     * @return void
+     */
+    protected function createFactory($modelNamespace)
+    {
+        $factory = Str::studly(class_basename($modelNamespace));
+
+        $this->call('make:factory', [
+            'name' => "{$factory}Factory",
+            '--model' => $this->qualifyClass($this->getNameInput()),
+        ]);
     }
 }

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -131,6 +131,11 @@ abstract class Factory {
         return $this;
     }
 
+    /**
+     * @param array $attributes
+     *
+     * @return \Illuminate\Support\Collection|\Illuminate\Database\Eloquent\Collection|\Illuminate\Database\Eloquent\Model[]|\Illuminate\Database\Eloquent\Model
+     */
     public function create($attributes = [])
     {
         $result = $this->make($attributes);
@@ -203,6 +208,11 @@ abstract class Factory {
         return $this;
     }
 
+    /**
+     * @param array $attributes
+     *
+     * @return \Illuminate\Support\Collection|\Illuminate\Database\Eloquent\Collection|\Illuminate\Database\Eloquent\Model[]|\Illuminate\Database\Eloquent\Model
+     */
     public function make($attributes = [])
     {
         if (empty($this->factory))

--- a/src/stubs/FactoryStub.model.txt
+++ b/src/stubs/FactoryStub.model.txt
@@ -9,5 +9,5 @@ use Lukeraymonddowning\Poser\Factory;
   * @method \Illuminate\Support\Collection|\Illuminate\Database\Eloquent\Collection|{{ ModelNamespace }}[]|{{ ModelNamespace }} make($attributes = [])
   */
 class {{ ClassName }} extends Factory {
-
+    protected static $modelName = {{ ModelNamespace }}::class;
 }


### PR DESCRIPTION
Resolves https://github.com/lukeraymonddowning/poser/issues/8

### IDE Autocomplete

The main part of this work was adding the docblocks to help IDEs with autocompletion, which involved working out the Model class from the factory name.

### Model flag

However, as there is also the option of changing the model name for the Poser factory, a `-model ModelName | -m ModelName`  flag was added that will allow for specifying the model at the point of creation.

### Factory Flag

Add a `-f | -factory` flag that will also generate the Laravel database factory as well.

This just calls the current artisan command, which will take care of all the checks, etc

### Other

The change to `GeneratorCommand` was due to it providing `$this->qualifyClass()` that will work out the namespace in the same way that Laravels make commands do