### PR TITLE
Added the ability to mass create factories 

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,8 +42,10 @@ Next, publish the Poser config file by calling
 
 `php artisan vendor:publish --tag=poser`
 
-To get started quickly, we provide a `php artisan make:poser` command. You should pass the desired name
+To get started quickly, we provide a `php artisan make:poser` command. You may pass the desired name
 of your factory as an argument. So the command to create the `UserFactory` would be `php artisan make:poser UserFactory`.
+
+If you want to let Poser do all of the work, simply call `php artisan make:poser` to turn all the models defined in your poser.models_directory config entry into Poser Factories.
 
 More of a visual person? [Watch this video demonstration of Poser](https://vimeo.com/395500107)
 

--- a/src/CreatePoserFactory.php
+++ b/src/CreatePoserFactory.php
@@ -5,10 +5,11 @@ namespace Lukeraymonddowning\Poser;
 use Illuminate\Support\Str;
 use Illuminate\Console\Command;
 use Illuminate\Support\Facades\File;
+use Illuminate\Database\Eloquent\Model;
 
-class CreatePoserFactory extends Command
-{
-    protected $signature = 'make:poser {name}';
+class CreatePoserFactory extends Command {
+
+    protected $signature = 'make:poser {name?}';
 
     protected $description = 'Creates a Poser Model Factory with the given name';
 
@@ -31,23 +32,34 @@ class CreatePoserFactory extends Command
     {
         $name = $this->argument('name');
 
-        $this->info("Creating Poser Factory called " . $name);
+        if ($name) {
+            $this->createFactory($name);
+            return;
+        }
+
+        $this->createAllFactories();
+    }
+
+    protected function createFactory($factoryName, $className = null)
+    {
+        $this->info("Creating Poser Factory called " . $factoryName);
 
         $factoriesDirectory = config('poser.factories_directory', 'Tests\\Factories');
 
-        $destinationDirectory = base_path()."/".str_replace("\\", "/", $factoriesDirectory);
+        $destinationDirectory = base_path() . "/" . str_replace("\\", "/", $factoriesDirectory);
 
         if (!File::exists($destinationDirectory))
             File::makeDirectory($destinationDirectory);
 
-        $destination = $destinationDirectory.$name.".php";
+        $destination = $destinationDirectory . $factoryName . ".php";
 
         if (File::exists($destination)) {
-            $this->error("There is already a Factory called " . $name . " at " . $destinationDirectory);
+            $this->error("There is already a Factory called " . $factoryName . " at " . $destinationDirectory);
+
             return;
         }
 
-        File::copy(__DIR__.'/stubs/FactoryStub.txt', $destination);
+        File::copy(__DIR__ . '/stubs/FactoryStub.txt', $destination);
 
         $value = file_get_contents($destination);
 
@@ -56,14 +68,35 @@ class CreatePoserFactory extends Command
             $namespace = Str::beforeLast($namespace, '\\');
 
         $valueWithNamespace = str_replace("{{ Namespace }}", $namespace, $value);
-        $valueFormatted = str_replace("{{ ClassName }}", $name, $valueWithNamespace);
+        $valueFormatted = str_replace("{{ ClassName }}", $factoryName, $valueWithNamespace);
 
         file_put_contents($destination, $valueFormatted);
 
-        $this->info($name . " successfully created at " . $destination);
+        $this->info($factoryName . " successfully created at " . $destination);
         $this->line("");
         $this->line("Remember, you should have a corresponding model, database factory and migration");
         $this->line("");
         $this->info("Please consider starring the repo at https://github.com/lukeraymonddowning/poser");
+    }
+
+    protected function createAllFactories()
+    {
+        $this->info("Creating Factories from all Models...");
+        collect(File::files(str_replace('\\', '/', config('poser.models_directory'))))
+            ->filter(function ($fileInfo) {
+                return class_exists(config('poser.models_directory') . File::name($fileInfo));
+            })->map(function ($fileInfo) {
+                return config('poser.models_directory') . File::name($fileInfo);
+            })->filter(function ($className) {
+                return is_subclass_of($className, Model::class);
+            })->map(function ($className) {
+                return Str::substr($className, Str::length(config('poser.models_directory')));
+            })->map(function ($modelType) {
+                return $modelType . "Factory";
+            })->filter(function ($factoryName) {
+                return !class_exists(config('poser.factories_directory', 'Tests\\Factories') . $factoryName);
+            })->each(function ($factoryName) {
+                $this->createFactory($factoryName);
+            });
     }
 }


### PR DESCRIPTION
Closes #10 

You can now omit the name property on the `make:poser` command to generate a factory for all models found in the defined models directory according to `config('poser.models_directory')`