### PR TITLE
Useful error message improvements

### DIFF
--- a/src/Exceptions/ModelNotBuiltException.php
+++ b/src/Exceptions/ModelNotBuiltException.php
@@ -1,0 +1,18 @@
+<?php
+
+
+namespace Lukeraymonddowning\Poser\Exceptions;
+
+
+use Exception;
+use Throwable;
+
+class ModelNotBuiltException extends Exception {
+
+    public function __construct($factory, $userCalled, $modelName = null)
+    {
+        $message = "You tried to call '" . $userCalled . "', but it doesn't exist on " . class_basename($factory)  . ". Were you trying to call " . $modelName . "::" . $userCalled . "? If so, don't forget to call either 'create()' or 'make()' on " . class_basename($factory) . ".";
+        parent::__construct($message, 0, null);
+    }
+
+}

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -11,6 +11,7 @@ use Illuminate\Support\Collection;
 use Tests\Factories\CustomerFactory;
 use Illuminate\Database\Eloquent\Model;
 use phpDocumentor\Reflection\Types\Integer;
+use Lukeraymonddowning\Poser\Exceptions\ModelNotBuiltException;
 use Lukeraymonddowning\Poser\Exceptions\ArgumentsNotSatisfiableException;
 
 abstract class Factory {
@@ -56,13 +57,20 @@ abstract class Factory {
     {
         if (Str::startsWith($name, 'with')) {
             $this->handleSaveMethodRelationships($name, $arguments);
+            return $this;
         }
 
         if (Str::startsWith($name, 'for')) {
             $this->handleBelongsToRelationships($name, $arguments);
+            return $this;
         }
 
-        return $this;
+        throw new ModelNotBuiltException($this, $name, $this->getModelName());
+    }
+
+    public function __get($name)
+    {
+        throw new ModelNotBuiltException($this, $name, $this->getModelName());
     }
 
     protected function handleSaveMethodRelationships($functionName, $arguments)


### PR DESCRIPTION
There is now a useful error message presented when you try to ask for a property or function of a model without first calling create() or make() on the factory.