### PR TITLE
First pass at cleanup of Factory.php

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,7 +7,7 @@ We accept contributions via Pull Requests on [Github](https://github.com/lukeray
 
 ## Pull Requests
 
-- **[PSR-2 Coding Standard](https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-2-coding-style-guide.md)** - The easiest way to apply the conventions is to install [PHP Code Sniffer](http://pear.php.net/package/PHP_CodeSniffer).
+- **[PSR-12 Coding Standard](https://www.php-fig.org/psr/psr-12/)** - Your IDE most likely has support for this. For PHPStorm, check out [this helpful resource](https://blog.jetbrains.com/phpstorm/2019/11/phpstorm-2019-3-release/#psr)
 
 - **Add tests!** - Your patch won't be accepted if it doesn't have tests.
 
@@ -15,7 +15,7 @@ We accept contributions via Pull Requests on [Github](https://github.com/lukeray
 
 - **Consider our release cycle** - We try to follow [SemVer v2.0.0](http://semver.org/). Randomly breaking public APIs is not an option.
 
-- **Create feature branches** - Don't askef us to pull from your master branch.
+- **Create feature branches** - Don't ask us to pull from your master branch.
 
 - **One pull request per feature** - If you want to do more than one thing, send multiple pull requests.
 

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,0 +1,26 @@
+# Upgrade Guide
+
+This guide will help you update your app built using Poser when moving up MAJOR version numbers.
+As Poser uses [semantic versioning](https://www.google.com/url?sa=t&rct=j&q=&esrc=s&source=web&cd=1&cad=rja&uact=8&ved=2ahUKEwiDj7vJ94foAhXtTRUIHeiSAiwQFjAAegQIARAB&url=https%3A%2F%2Fsemver.org%2F&usg=AOvVaw2wqeU7SPQk7aq7nuXGCrz-)
+there is no need to make any upgrade changes unless the major version number increases.
+
+## 1.x.x-beta - 2.x.x-beta
+Expected upgrade time: 0 minutes
+
+This update is mainly a cleanup. It refactors the abstract Factory class to be more readable and 
+easier to change in the future. No public methods have changed, so if you have not overridden 
+any protected properties or methods, you do not need to make any changes.
+
+### Changes to protected properties
+
+- `$saveMethodRelationships` is now called `$withRelationships`.
+- `$belongsToRelationships` is now called `$forRelationships`.
+
+### Changes to protected methods
+
+- `handleSaveMethodRelationships` is now called `handleWithRelationship`.
+- `handleBelongsToRelatioships` is now called `handleForRelationship`.
+- `getModelDataFromFunctionArguments` is now called `buildRelationshipData`.
+- `getFactoryFor` is now called `getFactoryNameFromFunctionNameOrFail`. It will also now throw an `ArgumentsNotSatisfiableException` if it cannot find the corresponding factory.
+- `addSaveMethodRelationships` is now called `buildAllWithRelationships`.
+- `addBelongsToRelationships` is now called `buildAllForRelationships`.

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -21,6 +21,6 @@ any protected properties or methods, you do not need to make any changes.
 - `handleSaveMethodRelationships` is now called `handleWithRelationship`.
 - `handleBelongsToRelatioships` is now called `handleForRelationship`.
 - `getModelDataFromFunctionArguments` is now called `buildRelationshipData`.
-- `getFactoryFor` is now called `getFactoryNameFromFunctionNameOrFail`. It will also now throw an `ArgumentsNotSatisfiableException` if it cannot find the corresponding factory.
+- `getFactoryFor` is now called `getFactoryNameFromMethodNameOrFail`. It will also now throw an `ArgumentsNotSatisfiableException` if it cannot find the corresponding factory.
 - `addSaveMethodRelationships` is now called `buildAllWithRelationships`.
 - `addBelongsToRelationships` is now called `buildAllForRelationships`.

--- a/src/CreatePoserFactory.php
+++ b/src/CreatePoserFactory.php
@@ -119,21 +119,35 @@ class CreatePoserFactory extends GeneratorCommand
     {
         $this->info("Creating Factories from all Models...");
         collect(File::files(str_replace('\\', '/', config('poser.models_directory'))))
-            ->filter(function ($fileInfo) {
-                return class_exists(config('poser.models_directory') . File::name($fileInfo));
-            })->map(function ($fileInfo) {
-                return config('poser.models_directory') . File::name($fileInfo);
-            })->filter(function ($className) {
-                return is_subclass_of($className, Model::class);
-            })->map(function ($className) {
-                return Str::substr($className, Str::length(config('poser.models_directory')));
-            })->map(function ($modelType) {
-                return $modelType . "Factory";
-            })->filter(function ($factoryName) {
-                return !class_exists(config('poser.factories_directory', 'Tests\\Factories') . $factoryName);
-            })->each(function ($factoryName) {
-                $this->createFactory($factoryName);
-            });
+            ->filter(
+                function ($fileInfo) {
+                    return class_exists(config('poser.models_directory') . File::name($fileInfo));
+                }
+            )->map(
+                function ($fileInfo) {
+                    return config('poser.models_directory') . File::name($fileInfo);
+                }
+            )->filter(
+                function ($className) {
+                    return is_subclass_of($className, Model::class);
+                }
+            )->map(
+                function ($className) {
+                    return Str::substr($className, Str::length(config('poser.models_directory')));
+                }
+            )->map(
+                function ($modelType) {
+                    return $modelType . "Factory";
+                }
+            )->filter(
+                function ($factoryName) {
+                    return !class_exists(config('poser.factories_directory', 'Tests\\Factories') . $factoryName);
+                }
+            )->each(
+                function ($factoryName) {
+                    $this->createFactory($factoryName);
+                }
+            );
     }
 
     /**
@@ -147,9 +161,12 @@ class CreatePoserFactory extends GeneratorCommand
     {
         $factory = Str::studly(class_basename($modelNamespace));
 
-        $this->call('make:factory', [
-            'name' => "{$factory}Factory",
-            '--model' => $this->qualifyClass($factory),
-        ]);
+        $this->call(
+            'make:factory',
+            [
+                'name' => "{$factory}Factory",
+                '--model' => $this->qualifyClass($factory),
+            ]
+        );
     }
 }

--- a/src/Exceptions/ArgumentsNotSatisfiableException.php
+++ b/src/Exceptions/ArgumentsNotSatisfiableException.php
@@ -13,8 +13,9 @@ class ArgumentsNotSatisfiableException extends Exception
         $message = "The relationship '" . $relationshipMethodName . "' could not be converted into a Poser Factory. You called '" . $callingClassName . "->" . $functionName . "()'. Are you sure there is a corresponding factory for " . $relationshipMethodName . "?";
 
         if (!empty($factoryNamesChecked)) {
-            $message .= " We checked for factories with the names '" . collect($factoryNamesChecked)->join("', '",
-                    "' and '") . "'.";
+            $message .= " We checked for factories with the names '" .
+                collect($factoryNamesChecked)->join("', '", "' and '") .
+                "'.";
         }
         parent::__construct($message, 0, null);
     }

--- a/src/Exceptions/ModelNotBuiltException.php
+++ b/src/Exceptions/ModelNotBuiltException.php
@@ -12,7 +12,12 @@ class ModelNotBuiltException extends Exception
 
     public function __construct($factory, $userCalled, $modelName = null)
     {
-        $message = "You tried to call '" . $userCalled . "', but it doesn't exist on " . class_basename($factory) . ". Were you trying to call " . $modelName . "::" . $userCalled . "? If so, don't forget to call either 'create()' or 'make()' on " . class_basename($factory) . ".";
+        $message = "You tried to call '" . $userCalled . "', but it doesn't exist on " .
+            class_basename($factory) .
+            ". Were you trying to call " .
+            $modelName . "::" . $userCalled .
+            "? If so, don't forget to call either 'create()' or 'make()' on " .
+            class_basename($factory) . ".";
         parent::__construct($message, 0, null);
     }
 

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -38,7 +38,7 @@ abstract class Factory
      */
     public static function new()
     {
-        return new static();
+        return self::times(1);
     }
 
     /**
@@ -48,7 +48,7 @@ abstract class Factory
      * @param int $count
      * @return static
      */
-    public static function times($count)
+    public static function times(int $count)
     {
         $factory = new static();
         $factory->count = $count;
@@ -58,6 +58,7 @@ abstract class Factory
 
     public function __construct()
     {
+        $this->factory = factory($this->getModelName());
         $this->saveMethodRelationships = collect([]);
         $this->belongsToRelationships = collect([]);
     }
@@ -70,12 +71,12 @@ abstract class Factory
      *
      * @return \Illuminate\Database\Eloquent\Collection|Model|Model[]|Collection
      */
-    public function __invoke($attributes = [])
+    public function __invoke(array $attributes = [])
     {
         return $this->create($attributes);
     }
 
-    public function __call($name, $arguments)
+    public function __call(string $name, array $arguments)
     {
         if (Str::startsWith($name, 'with')) {
             $this->handleSaveMethodRelationships($name, $arguments);
@@ -92,7 +93,7 @@ abstract class Factory
         throw new ModelNotBuiltException($this, $name, $this->getModelName());
     }
 
-    public function __get($name)
+    public function __get(string $name)
     {
         throw new ModelNotBuiltException($this, $name, $this->getModelName());
     }
@@ -106,7 +107,7 @@ abstract class Factory
      *
      * @return $this
      */
-    public function withAttributes($attributes)
+    public function withAttributes(array $attributes)
     {
         $this->attributes = $attributes;
 
@@ -122,7 +123,7 @@ abstract class Factory
      *
      * @return $this
      */
-    public function withPivotAttributes($attributes)
+    public function withPivotAttributes(array $attributes)
     {
         $this->pivotAttributes = $attributes;
 
@@ -137,7 +138,7 @@ abstract class Factory
      *
      * @return $this
      */
-    public function as($state)
+    public function as(string $state)
     {
         return $this->state($state);
     }
@@ -150,11 +151,9 @@ abstract class Factory
      *
      * @return $this
      */
-    public function state($state)
+    public function state(string $state)
     {
-        $this->states[] = $state;
-
-        return $this;
+        return $this->states($state);
     }
 
     /**
@@ -183,33 +182,25 @@ abstract class Factory
      *
      * @return \Illuminate\Support\Collection|\Illuminate\Database\Eloquent\Collection|\Illuminate\Database\Eloquent\Model[]|\Illuminate\Database\Eloquent\Model
      */
-    public function create($attributes = [])
+    public function create(array $attributes = [])
     {
         $result = $this->make($attributes);
 
-        $this->performActionToModels($result, function ($model) {
+        $returnFirstCollectionResultAtEnd = !$result instanceof Collection;
+        $result = $returnFirstCollectionResultAtEnd ? collect([$result]) : $result;
+
+        $result->each(function ($model) {
             $this->addBelongsToRelationships($model);
+            $model->save();
         });
 
-        if ($result instanceof Collection) {
-            $result->each(function ($model) {
-                $model->save();
-            });
-        } elseif ($result instanceof Model) {
-            $result->save();
-        }
+        $this->factory->callAfterCreating($returnFirstCollectionResultAtEnd ? $result->first() : $result);
 
-        $this->factory->callAfterCreating($result);
+        $result->each(function ($model) {
+            $this->addSaveMethodRelationships($model);
+        });
 
-        if ($result instanceof Collection) {
-            $result->each(function ($model) {
-                $this->addSaveMethodRelationships($model);
-            });
-        } elseif ($result instanceof Model) {
-            $this->addSaveMethodRelationships($result);
-        }
-
-        return $result;
+        return $returnFirstCollectionResultAtEnd ? $result->first() : $result;
     }
 
     /**
@@ -221,36 +212,28 @@ abstract class Factory
      *
      * @return \Illuminate\Support\Collection|\Illuminate\Database\Eloquent\Collection|\Illuminate\Database\Eloquent\Model[]|\Illuminate\Database\Eloquent\Model
      */
-    public function make($attributes = [])
+    public function make(array $attributes = [])
     {
-        if (empty($this->factory)) {
-            $this->factory = factory($this->getModelName());
-        }
-
-        $this->factory->states($this->states);
-
         if ($this->count > 1) {
             $this->factory->times($this->count);
         }
 
-        $result = $this->factory->make(array_merge($this->attributes, $attributes));
-
-        return $result;
+        return $this->factory->states($this->states)->make(array_merge($this->attributes, $attributes));
     }
 
-    protected function handleSaveMethodRelationships($functionName, $arguments)
+    protected function handleSaveMethodRelationships(string $functionName, array $arguments)
     {
         $this->saveMethodRelationships[$this->getRelationshipMethodName($functionName)] = $this->getModelDataFromFunctionArguments($functionName,
             $arguments);
     }
 
-    protected function handleBelongsToRelationships($functionName, $arguments)
+    protected function handleBelongsToRelationships(string $functionName, array $arguments)
     {
         $this->belongsToRelationships[$this->getRelationshipMethodName($functionName)] = $this->getModelDataFromFunctionArguments($functionName,
             $arguments);
     }
 
-    private function getRelationshipMethodName($functionName)
+    private function getRelationshipMethodName(string $functionName)
     {
         $prefix = collect(static::$relationshipPrefixes)->filter(function ($prefix) use ($functionName) {
             return Str::contains($functionName, $prefix);
@@ -259,107 +242,98 @@ abstract class Factory
         return Str::camel(Str::after($functionName, $prefix));
     }
 
-    private function getModelDataFromFunctionArguments($functionName, $arguments)
+    private function getModelDataFromFunctionArguments(string $functionName, array $arguments)
     {
-        if (isset($arguments[0]) && !is_int($arguments[0]) && !is_array($arguments[0])) {
+        if ($this->factoryShouldBeHandledManually($arguments)) {
             return $arguments[0];
         }
 
-        $relationshipMethodName = $this->getRelationshipMethodName($functionName);
-        $factory = $this->getFactoryFor($relationshipMethodName);
+        $factory = call_user_func(
+            $this->getFactoryNameForRelationshipOrFail($functionName) . '::times',
+            isset($arguments[0]) && is_int($arguments[0]) ? $arguments[0] : 1
+        );
 
-        if (empty($factory)) {
-            throw new ArgumentsNotSatisfiableException(class_basename($this), $functionName, $relationshipMethodName, [
-                $this->generateFactoryName($relationshipMethodName),
-                $this->generateFactoryName($relationshipMethodName, "Factory")
-            ]);
-        }
-
-        $factory = isset($arguments[0]) && is_int($arguments[0]) ? call_user_func($factory . '::times',
-            $arguments[0]) : call_user_func($factory . '::new');
-
-        if (isset($arguments[0]) && is_array($arguments[0])) {
-            $factory->withAttributes($arguments[0]);
-        }
-
-        if (isset($arguments[1]) && is_array($arguments[1])) {
-            $factory->withAttributes($arguments[1]);
-        }
+        collect($arguments)->filter(function ($argument) {
+            return is_array($argument);
+        })->first(function ($attributes) use ($factory) {
+            $factory->withAttributes($attributes);
+        });
 
         return $factory;
     }
 
-    protected function getFactoryFor($relationshipMethodName)
+    private function factoryShouldBeHandledManually($arguments)
     {
-        if (class_exists($this->generateFactoryName($relationshipMethodName))) {
-            return $this->generateFactoryName($relationshipMethodName);
-        }
-
-        if (class_exists($this->generateFactoryName($relationshipMethodName, "Factory"))) {
-            return $this->generateFactoryName($relationshipMethodName, "Factory");
-        }
-
-        return null;
+        return isset($arguments[0]) && !is_int($arguments[0]) && !is_array($arguments[0]);
     }
 
-    private function generateFactoryName($relationshipMethodName, $suffix = "")
+    protected function getFactoryNameForRelationshipOrFail(string $functionName)
+    {
+        $relationshipMethodName = $this->getRelationshipMethodName($functionName);
+
+        return collect(["", "Factory"])->map(function ($suffix) use ($relationshipMethodName) {
+            return $this->generateFactoryName($relationshipMethodName, $suffix);
+        })->filter(function ($class) {
+            return class_exists($class);
+        })->whenEmpty(function () use ($functionName, $relationshipMethodName) {
+            throw new ArgumentsNotSatisfiableException(class_basename($this), $functionName,
+                $relationshipMethodName, [
+                    $this->generateFactoryName($relationshipMethodName),
+                    $this->generateFactoryName($relationshipMethodName, "Factory")
+                ]);
+        })->first();
+    }
+
+    private function generateFactoryName(string $relationshipMethodName, string $suffix = "")
     {
         $factoryLocation = config('poser.factories_directory', "Tests\\Factories\\");
 
         return $factoryLocation . Str::studly(Str::singular($relationshipMethodName)) . $suffix;
     }
 
-    private function performActionToModels($models, $closure)
-    {
-        if ($models instanceof Collection) {
-            $models->each(function ($model) use ($closure) {
-                $closure($model);
-            });
-        } elseif ($models instanceof Model) {
-            $this->addBelongsToRelationships($models);
-        }
-    }
-
     protected function addSaveMethodRelationships($model)
     {
         $this->saveMethodRelationships->each(function ($relatedModels, $relationshipName) use ($model) {
-            $pivotAttributes = collect($relatedModels instanceof Factory ? $relatedModels->pivotAttributes : []);
-            $models = $relatedModels instanceof Factory ? $relatedModels->make() : $relatedModels;
+            $models = $this->makeModels($relatedModels);
 
             if ($models instanceof Model) {
                 $models = collect([$models]);
             }
 
-            $models->each(function ($relatedModel) use ($model, $relationshipName, $pivotAttributes) {
-                $model->{$relationshipName}()->save($relatedModel, $pivotAttributes->toArray());
-            });
+            $models->each(function ($relatedModel) use ($model, $relationshipName, $relatedModels) {
+                $model->{$relationshipName}()->save($relatedModel, $relatedModels->pivotAttributes ?? []);
 
-            if ($relatedModels instanceof Factory) {
-                $models->each(function ($model) use ($relatedModels) {
-                    $relatedModels->addSaveMethodRelationships($model);
-                });
-            }
+                if ($relatedModels instanceof Factory) {
+                    $relatedModels->addSaveMethodRelationships($relatedModel);
+                }
+            });
         });
 
         return $this;
     }
 
-    protected function addBelongsToRelationships($model)
+    protected function addBelongsToRelationships(Model $model)
     {
         $this->belongsToRelationships->each(function ($owningModel, $relationshipName) use ($model) {
-            $owningModel = $owningModel instanceof Factory ? $owningModel->create() : $owningModel;
-            $model->{$relationshipName}()->associate($owningModel);
+            $model->{$relationshipName}()->associate($this->createModels($owningModel));
         });
 
         return $this;
+    }
+
+    private function makeModels($modelDefinition)
+    {
+        return $modelDefinition instanceof Factory ? $modelDefinition->make() : $modelDefinition;
+    }
+
+    private function createModels($modelDefinition)
+    {
+        return $modelDefinition instanceof Factory ? $modelDefinition->create() : $modelDefinition;
     }
 
     protected function getModelName()
     {
-        if (!empty(static::$modelName)) {
-            return static::$modelName;
-        }
-
-        return config('poser.models_directory', "App\\") . Str::beforeLast(class_basename($this), "Factory");
+        return static::$modelName ??
+            config('poser.models_directory', "App\\") . Str::beforeLast(class_basename($this), "Factory");
     }
 }

--- a/src/PoserServiceProvider.php
+++ b/src/PoserServiceProvider.php
@@ -17,14 +17,10 @@ class PoserServiceProvider extends ServiceProvider
 
     public function boot()
     {
-        $this->publishes([
-            __DIR__ . '/config/poser.php' => config_path('poser.php')
-        ], 'poser');
+        $this->publishes([__DIR__ . '/config/poser.php' => config_path('poser.php')], 'poser');
 
         if ($this->app->runningInConsole()) {
-            $this->commands([
-                CreatePoserFactory::class
-            ]);
+            $this->commands([CreatePoserFactory::class]);
         }
     }
 }


### PR DESCRIPTION
Renamed methods where appropriate, simplified logic and improved readability.

- No public method names have been changed, and the functionality remains identical.
- Some protected and private method names have changed, where appropriate, to better reflect the action that the method is taking 