### PR TITLE
The stubs will now include a docblock for the __invoke() function

### DIFF
--- a/src/stubs/FactoryStub.model.txt
+++ b/src/stubs/FactoryStub.model.txt
@@ -5,6 +5,7 @@ namespace {{ Namespace }};
 use Lukeraymonddowning\Poser\Factory;
 
 /**
+  * @method \Illuminate\Support\Collection|\Illuminate\Database\Eloquent\Collection|{{ ModelNamespace }}[]|{{ ModelNamespace }} __invoke($attributes = [])
   * @method \Illuminate\Support\Collection|\Illuminate\Database\Eloquent\Collection|{{ ModelNamespace }}[]|{{ ModelNamespace }} create($attributes = [])
   * @method \Illuminate\Support\Collection|\Illuminate\Database\Eloquent\Collection|{{ ModelNamespace }}[]|{{ ModelNamespace }} make($attributes = [])
   */

--- a/src/stubs/FactoryStub.txt
+++ b/src/stubs/FactoryStub.txt
@@ -5,6 +5,7 @@ namespace {{ Namespace }};
 use Lukeraymonddowning\Poser\Factory;
 
 /**
+  * @method \Illuminate\Support\Collection|\Illuminate\Database\Eloquent\Collection|{{ ModelNamespace }}[]|{{ ModelNamespace }} __invoke($attributes = [])
   * @method \Illuminate\Support\Collection|\Illuminate\Database\Eloquent\Collection|{{ ModelNamespace }}[]|{{ ModelNamespace }} create($attributes = [])
   * @method \Illuminate\Support\Collection|\Illuminate\Database\Eloquent\Collection|{{ ModelNamespace }}[]|{{ ModelNamespace }} make($attributes = [])
   */


### PR DESCRIPTION
Using the syntax `UserFactory::new()->withAddress()()` will now have the same IDE support as `UserFactory::new()->withAddress()->create()` when using `php artisan make:poser`