### PR TITLE
Directories to namespaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,5 @@
+# 3.0.1-beta
+- The `poser.models_directory` config entry has been renamed to `poser.models_namespace`. Whilst the former will still work,
+it is deprecated and should be replaced with the latter. It will be removed completely in the next MAJOR version.
+- The `poser.factories_directory` config entry has been renamed to `poser.factories_namespace`. Whilst the former will still work,
+it is deprecated and should be replaced with the latter. It will be removed completely in the next MAJOR version.

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Next, publish the Poser config file by calling
 To get started quickly, we provide a `php artisan make:poser` command. You may pass the desired name
 of your factory as an argument. So the command to create the `UserFactory` would be `php artisan make:poser UserFactory`.
 
-If you want to let Poser do all of the work, simply call `php artisan make:poser` to turn all the models defined in your poser.models_directory config entry into Poser Factories.
+If you want to let Poser do all of the work, simply call `php artisan make:poser` to turn all the models defined in your poser.models_namespace config entry into Poser Factories.
 
 More of a visual person? [Watch this video demonstration of Poser](https://vimeo.com/395500107)
 
@@ -489,14 +489,14 @@ be called on the related factory, not the root-level factory.
 ### `php artisan make:poser` API
 
 If no arguments are passed to the command, Poser will attempt to create matching factories for every model in your 
-application. It does this by looking at your `poser.model_directory` config entry, and scanning for models in that given
-directory. You may call `make:poser` multiple times without fear of it overriding your existing factories; if it finds
+application. It does this by looking at your `poser.models_namespace` config entry, and scanning for models in that given
+namespace. You may call `make:poser` multiple times without fear of it overriding your existing factories; if it finds
 that a given factory already exists, it will simply skip over it.
 
 #### Individual Factories
 You may optionally pass a name to the command, which corresponds to the name of the factory you want to create. For
 instance, `php artisan make:poser UserFactory` would create a factory called `UserFactory` in the namespace defined
-in your `poser.factories_directory` config file.
+in your `poser.factories_namespace` config file.
 
 #### The `-m` or `-model` Flag
 If your model name is different to the name you wish to give your factory, you may pass a `-m` or `-model` flag, along 
@@ -510,7 +510,7 @@ The database factory will take the form `[modelName]Factory`.
 ### Things to note
 #### Models location
 By default, Poser looks for your models in the `App` directory, which should be fine for most projects.
-If you have your models in a different directory, you can let Poser know about it by editing the `models_directory`
+If you have your models in a different directory, you can let Poser know about it by editing the `models_namespace`
 entry in the `poser.php` config file.
 
 If you need to override the model location for a single instance, you can override the `$modelName` static variable
@@ -519,7 +519,7 @@ in your Factory class, passing it the fully qualified class name of the correspo
 #### Factories location
 By default, Poser will search the `Tests/Factories` directory for your Factory classes.
 If you have your Factories in a different directory (eg: `Tests/Models/Factories`),
-you can let Poser know about it by editing the `factories_directory` entry in the poser.php config
+you can let Poser know about it by editing the `factories_namespace` entry in the poser.php config
 file.
 
 #### The `->create()` and `->make()` commands

--- a/README.md
+++ b/README.md
@@ -582,6 +582,9 @@ When we call `UserFactory::new()->withClients()()`, Poser understands that you'r
 UserFactory::new()->withClients(CustomerFactory::times(10))();
 ```
 
+## Changelog
+Take a look at the `CHANGELOG.md` file for details on changes from update to update.
+
 ## Credits
 
 - [Luke Raymond Downing](https://github.com/lukeraymonddowning)

--- a/src/CreatePoserFactory.php
+++ b/src/CreatePoserFactory.php
@@ -48,15 +48,12 @@ class CreatePoserFactory extends GeneratorCommand
     {
         $this->info("Creating Poser Factory called " . $factoryName);
 
-        $factoriesDirectory = config('poser.factories_directory', 'Tests\\Factories');
-        $modelsDirectory = config('poser.models_directory', 'App\\');
-
-        $expectedModelNameSpace = '\\' . $modelsDirectory . Str::beforeLast($factoryName, 'Factory');
+        $expectedModelNameSpace = '\\' . modelsNamespace() . Str::beforeLast($factoryName, 'Factory');
         $linkedModelNamespace = $this->option('model')
             ? '\\' . $this->qualifyClass($this->option('model'))
             : $expectedModelNameSpace;
 
-        $destinationDirectory = base_path() . "/" . str_replace("\\", "/", $factoriesDirectory);
+        $destinationDirectory = base_path() . "/" . str_replace("\\", "/", factoriesNamespace());
 
         if (!File::exists($destinationDirectory)) {
             File::makeDirectory($destinationDirectory);
@@ -79,7 +76,7 @@ class CreatePoserFactory extends GeneratorCommand
 
         $value = file_get_contents($destination);
 
-        $namespace = str_replace('/', '\\', $factoriesDirectory);
+        $namespace = str_replace('/', '\\', factoriesNamespace());
         if (Str::endsWith($namespace, '\\')) {
             $namespace = Str::beforeLast($namespace, '\\');
         }
@@ -118,14 +115,14 @@ class CreatePoserFactory extends GeneratorCommand
     protected function createAllFactories()
     {
         $this->info("Creating Factories from all Models...");
-        collect(File::files(str_replace('\\', '/', config('poser.models_directory'))))
+        collect(File::files(str_replace('\\', '/', modelsNamespace())))
             ->filter(
                 function ($fileInfo) {
-                    return class_exists(config('poser.models_directory') . File::name($fileInfo));
+                    return class_exists(modelsNamespace() . File::name($fileInfo));
                 }
             )->map(
                 function ($fileInfo) {
-                    return config('poser.models_directory') . File::name($fileInfo);
+                    return modelsNamespace() . File::name($fileInfo);
                 }
             )->filter(
                 function ($className) {
@@ -133,7 +130,7 @@ class CreatePoserFactory extends GeneratorCommand
                 }
             )->map(
                 function ($className) {
-                    return Str::substr($className, Str::length(config('poser.models_directory')));
+                    return Str::substr($className, Str::length(modelsNamespace()));
                 }
             )->map(
                 function ($modelType) {
@@ -141,7 +138,7 @@ class CreatePoserFactory extends GeneratorCommand
                 }
             )->filter(
                 function ($factoryName) {
-                    return !class_exists(config('poser.factories_directory', 'Tests\\Factories') . $factoryName);
+                    return !class_exists(factoriesNamespace() . $factoryName);
                 }
             )->each(
                 function ($factoryName) {

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -363,9 +363,7 @@ abstract class Factory
      */
     protected function getFactoryName(string $relationshipMethodName, string $suffix = "")
     {
-        $factoryLocation = config('poser.factories_directory', "Tests\\Factories\\");
-
-        return $factoryLocation . Str::studly(Str::singular($relationshipMethodName)) . $suffix;
+        return factoriesNamespace() . Str::studly(Str::singular($relationshipMethodName)) . $suffix;
     }
 
     /**
@@ -428,6 +426,6 @@ abstract class Factory
     protected function getModelName()
     {
         return static::$modelName ??
-            config('poser.models_directory', "App\\") . Str::beforeLast(class_basename($this), "Factory");
+            modelsNamespace() . Str::beforeLast(class_basename($this), "Factory");
     }
 }

--- a/src/PoserServiceProvider.php
+++ b/src/PoserServiceProvider.php
@@ -17,10 +17,16 @@ class PoserServiceProvider extends ServiceProvider
 
     public function boot()
     {
+        $this->registerHelpers();
         $this->publishes([__DIR__ . '/config/poser.php' => config_path('poser.php')], 'poser');
 
         if ($this->app->runningInConsole()) {
             $this->commands([CreatePoserFactory::class]);
         }
+    }
+
+    protected function registerHelpers()
+    {
+        include_once __DIR__ . "/helpers.php";
     }
 }

--- a/src/config/poser.php
+++ b/src/config/poser.php
@@ -4,28 +4,28 @@ return [
 
     /*
     |--------------------------------------------------------------------------
-    | Models Directory
+    | Models Namespace
     |--------------------------------------------------------------------------
     |
-    | By default, Poser will search the root of the 'App/' directory for your models.
-    | If you have your models in a different directory (eg: 'App/Models/'),
-    | you may override this with the path of your model directory.
+    | By default, Poser will search the root of the 'App/' namespace for your models.
+    | If you have your models in a different namespace (eg: 'App\\Models\\'),
+    | you may override this with the path of your model namespace.
     |
     */
 
-    "models_directory" => "App\\",
+    "models_namespace" => "App\\",
 
     /*
     |--------------------------------------------------------------------------
-    | Factories Directory
+    | Factories Namespace
     |--------------------------------------------------------------------------
     |
     | By default, Poser will search the root of the 'Tests/Factories' directory for your Factory classes.
-    | If you have your Factories in a different directory (eg: 'Tests/Models/Factories'),
-    | you may override this with the path of your Factory directory.
+    | If you have your Factories in a different namespace (eg: 'Tests\\Models\\Factories'),
+    | you may override this with the path of your Factory namespace.
     |
     */
 
-    "factories_directory" => "Tests\\Factories\\"
+    "factories_namespace" => "Tests\\Factories\\"
 
 ];

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -1,0 +1,15 @@
+<?php
+
+if (!function_exists('modelsNamespace')) {
+    function modelsNamespace()
+    {
+        return config('poser.models_namespace', config('poser.models_directory', "App\\"));
+    }
+}
+
+if (!function_exists('factoriesNamespace')) {
+    function factoriesNamespace()
+    {
+        return config('poser.factories_namespace', config('poser.factories_directory', "Tests\\Factories\\"));
+    }
+}


### PR DESCRIPTION
Config entries have been renamed from 'x_directory' to 'x_namespace' to better reflect their purpose. This is backward compatible, but the 'x_directory' form is now deprecated.