### PR TITLE
Add afterCreating method to replicate the afterCreatingState logic from Laravel's database factories

### DIFF
--- a/src/Factory.php
+++ b/src/Factory.php
@@ -25,6 +25,7 @@ abstract class Factory
         $count = 1,
         $withRelationships,
         $forRelationships,
+        $afterCreating,
         $attributes = [],
         $pivotAttributes = [],
         $states = [];
@@ -61,6 +62,7 @@ abstract class Factory
         $this->factory = factory($this->getModelName());
         $this->withRelationships = collect([]);
         $this->forRelationships = collect([]);
+        $this->afterCreating = collect([]);
     }
 
     /**
@@ -199,6 +201,7 @@ abstract class Factory
         );
 
         $this->factory->callAfterCreating($returnFirstCollectionResultAtEnd ? $result->first() : $result);
+        $this->processAfterCreating($result);
 
         $result->each(
             function ($model) {
@@ -225,6 +228,20 @@ abstract class Factory
         }
 
         return $this->factory->states($this->states)->make(array_merge($this->attributes, $attributes));
+    }
+
+    /**
+     * Provide a closure that will be called after the factory has created the record(s)
+     *
+     * @param \Closure $closure
+     *
+     * @return $this
+     */
+    public function afterCreating(\Closure $closure)
+    {
+        $this->afterCreating->push($closure);
+
+        return $this;
     }
 
     /**
@@ -418,6 +435,26 @@ abstract class Factory
         );
 
         return $this;
+    }
+
+    /**
+     * Process any closures added to the afterCreating collection
+     *
+     * The created model will be passed into the closure as the first param
+     *
+     * @param \Illuminate\Support\Collection $result
+     */
+    protected function processAfterCreating(Collection $result)
+    {
+        if ($this->afterCreating->isEmpty()) {
+            return;
+        }
+
+        $result->each(function($model) {
+            $this->afterCreating->each(function($closure) use ($model) {
+                $closure($model);
+            });
+        });
     }
 
     /**

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -446,10 +446,6 @@ abstract class Factory
      */
     protected function processAfterCreating(Collection $result)
     {
-        if ($this->afterCreating->isEmpty()) {
-            return;
-        }
-
         $result->each(function($model) {
             $this->afterCreating->each(function($closure) use ($model) {
                 $closure($model);


### PR DESCRIPTION
This will allow you to use an `afterCreating` method that allows for a closure to be passed in. 

The created record will be passed into the closure allowing for any custom logic to be ran on the created records.

Example:
- User belongs to a company
- Company has a single Main user (stored on company record)
  - `setMainUser` on Company is a function to just update the `main_user_id` column on Company

```php
CompanyFactory::new()
    ->afterCreating(\App\Company $company) {
        $company->setMainUser(UserFactory::new()->forCompany($company)->create());
    })->create();
```

This could then be added as a custom method (`withMainUser`) on the CompanyFactory to reuse 😄 

Atm, this is only working on the current factory, I have not yet figured out how to also be able to get this running on relationship models, so that you can add an `afterCreating` on any relationship factory. (this could be looked at later)

I still need to update the docs for this too before merging

Thoughts so for @lukeraymonddowning?

Resolves https://github.com/lukeraymonddowning/poser/issues/19