### PR TITLE
Automated `create` functionality added

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,3 +3,9 @@
 it is deprecated and should be replaced with the latter. It will be removed completely in the next MAJOR version.
 - The `poser.factories_directory` config entry has been renamed to `poser.factories_namespace`. Whilst the former will still work,
 it is deprecated and should be replaced with the latter. It will be removed completely in the next MAJOR version.
+
+# 2.3.0-beta
+- Poser is now able to call `create` automatically when a method or property that should belong to the created model/collection
+is accessed. This is especially useful for `for[RealtionshipMethodName]` relationships, which used to have to be created. Now you
+can treat them the same as their `with` counterparts. Please note that this will not work if you never access a property or method 
+from the model in your tests. In that case, simply use the `create` or `()` method calls.

--- a/README.md
+++ b/README.md
@@ -248,6 +248,21 @@ public function user_has_address()
 }
 ```
 
+In most cases, we don't even need to call `create`, Poser will call it for us when we try to access a method or property
+on the model or collection we have built (in this case, the `$user` property).
+```php
+/** @test */
+public function user_has_address()
+{
+    $user = UserFactory::new()
+        ->hasAddress([
+            "line_1" => "1 Test Street" 
+        ]);
+
+    $this->assertNotEmpty($user->address); // When we access the $address property, Poser automatically calls `create` for us.
+}
+```
+
 Let's now put this all together, and demonstrate how simple it is to world build in Poser. Imagine we
 want 10 Users, each with an Address and 20 customers. Each customer should have 5 books. That should 
 be 10 `User`s, 10 `Address`es, 200 `Customer`s and 1000 `Book`s. Check it out:
@@ -276,7 +291,9 @@ the `CustomerFactory`, simply passing the integer `5`. Poser looks for a `BookFa
 and automatically calls `BookFactory::times(5)` under the hood.
 
 Finally, we complete the statement by invoking the UserFactory with `()`. This is a shorthand syntax
-for calling `create()` on the `UserFactory`.
+for calling `create()` on the `UserFactory`. Because in these tests we are accessing the models indirectly 
+(we request the models from the database in the assertions rather than accessing a property or method on the users), 
+we must invoke the `create` or `()` method.
 
 For reference, the same test using Laravel's built in factories looks like this:
 
@@ -366,7 +383,7 @@ public function a_user_can_have_many_comments() {
 
 /** @test */
 public function a_customer_can_have_many_comments() {
-    $customer = CustomerFactory::new()->withComments(25)->forUser(UserFactory::new()())();
+    $customer = CustomerFactory::new()->withComments(25)->forUser(UserFactory::new())();
 
     $this->assertCount(25, $customer->comments);
 }
@@ -385,12 +402,14 @@ public function customer_has_user()
 {
     $customer = CustomerFactory::new()
         ->forUser(
-            UserFactory::new()->create()
+            UserFactory::new()
         )->create();
 
     $this->assertNotEmpty($customer->user);
 }
 ```
+
+No need to call `create` on the `UserFactory` either; Poser will do that for you!
 
 ### Factory States
 If you have setup any States in your laravel factories, then you can also use them with Poser.
@@ -525,6 +544,10 @@ Use this to instantiate the class when you wish to create multiple entries in th
 Similar to the Laravel factory `create` command, this will create the models, persisting them to the database.
 You may pass an associative array of column names with desired values, which will be applied to the 
 created models. You can optionally call create by invoking the Factory. This allows for a shorter syntax.
+
+If you're interacting with the models directly in your tests, rather than re-fetching them from the database,
+you can omit the `create` call completely. Poser will automatically call the `create` method for you when you
+try to access a property or call a method on the model(s)/collection.
 
 #### `->make(array $attributes)`
 Similar to the Laravel factory `make` command, this will make the models without persisting them to the 

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -3,16 +3,10 @@
 
 namespace Lukeraymonddowning\Poser;
 
-use Closure;
-use App\User;
 use Mockery\Exception;
 use Illuminate\Support\Str;
-use Tests\Factories\UserFactory;
 use Illuminate\Support\Collection;
-use Illuminate\Support\Facades\DB;
-use Tests\Factories\CustomerFactory;
 use Illuminate\Database\Eloquent\Model;
-use phpDocumentor\Reflection\Types\Integer;
 use Lukeraymonddowning\Poser\Exceptions\ModelNotBuiltException;
 use Lukeraymonddowning\Poser\Exceptions\ArgumentsNotSatisfiableException;
 

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -97,6 +97,7 @@ abstract class Factory
 
         try {
             $model = $this->createdInstance ?? $this->create();
+
             return call_user_func_array([$model, $name], $arguments);
         } catch (Exception $e) {
             throw new ModelNotBuiltException($this, $name, $this->getModelName());
@@ -107,6 +108,7 @@ abstract class Factory
     {
         try {
             $model = $this->createdInstance ?? $this->create();
+
             return $model->$name;
         } catch (Exception $e) {
             throw new ModelNotBuiltException($this, $name, $this->getModelName());
@@ -223,6 +225,7 @@ abstract class Factory
         );
 
         $this->createdInstance = $returnFirstCollectionResultAtEnd ? $result->first() : $result;
+
         return $this->createdInstance;
     }
 


### PR DESCRIPTION
Been thinking about this for a little while. I often forget to call `create()` or `()` on the factories when writing tests (and I built it!), so I imagine there are others who forget too. This is especially the case in `for[RelationshipMethodName]` examples, where I forget to create the owning model.

As such, I've been working on this feature, which will automatically call create on factories when a property or function of the built instance is called which doesn't exist in the factory. If it still doesn't exist in the created model/collection, we throw the ModelNotBuiltException as we have before.

Here is an example:

```php
/** @test */
    public function it_works_with_for_relationships()
    {
        $customers = CustomerFactory::times(3)->forUser(UserFactory::new());

        $customers->each(
            function ($customer) {
                $this->assertInstanceOf(User::class, $customer->user);
            }
        );
    }
```

You can see we didn't have to call `create()` on either the `CustomerFactory` or the `UserFactory`, but the test passes fine.

@AlanHolmes, @andreich1980 do you guys see a value in this or potential pitfalls?

The only case it wouldn't work for is something like `$this->assertCount(n, Customer::all())` but I don't necessarily think that is a very good way of testing anyway.