### PR TITLE
More tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /.idea
 /vendor
 .phpunit.result.cache
+/Lukeraymonddowning/

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
 /.idea
 /vendor
 .phpunit.result.cache
-/Lukeraymonddowning/

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Next, publish the Poser config file by calling
 To get started quickly, we provide a `php artisan make:poser` command. You may pass the desired name
 of your factory as an argument. So the command to create the `UserFactory` would be `php artisan make:poser UserFactory`.
 
-If you want to let Poser do all of the work, simply call `php artisan make:poser` to turn all the models defined in your poser.models_namespace config entry into Poser Factories.
+If you want to let Poser do all of the work, simply call `php artisan make:poser` to turn all the models defined in your `poser.models_namespace` config entry into Poser Factories.
 
 More of a visual person? [Watch this video demonstration of Poser](https://vimeo.com/395500107)
 
@@ -591,13 +591,13 @@ You may optionally pass a name to the command, which corresponds to the name of 
 instance, `php artisan make:poser UserFactory` would create a factory called `UserFactory` in the namespace defined
 in your `poser.factories_namespace` config file.
 
-#### The `-m` or `-model` Flag
-If your model name is different to the name you wish to give your factory, you may pass a `-m` or `-model` flag, along 
+#### The `-m` or `--model` Flag
+If your model name is different to the name you wish to give your factory, you may pass a `-m` or `--model` flag, along 
 with the name of the model that the factory will correspond to. So `php artisan make:poser ClientFactory -m Customer`
 would create a factory called `ClientFactory`, but point it to the `Customer` model.
 
-#### The `-f` or `-factory` Flag
-You may pass `-f` or `-factory` to the command to optionally generate a corresponding [Laravel database factory](https://laravel.com/docs/database-testing#writing-factories). 
+#### The `-f` or `--factory` Flag
+You may pass `-f` or `--factory` to the command to optionally generate a corresponding [Laravel database factory](https://laravel.com/docs/database-testing#writing-factories). 
 The database factory will take the form `[modelName]Factory`.
 
 ### Things to note
@@ -612,7 +612,7 @@ in your Factory class, passing it the fully qualified class name of the correspo
 #### Factories location
 By default, Poser will search the `Tests/Factories` directory for your Factory classes.
 If you have your Factories in a different directory (eg: `Tests/Models/Factories`),
-you can let Poser know about it by editing the `factories_namespace` entry in the poser.php config
+you can let Poser know about it by editing the `factories_namespace` entry in the `poser.php` config
 file.
 
 #### The `->create()` and `->make()` commands
@@ -667,7 +667,7 @@ public function the_user_has_a_name() {
 This error is thrown when Poser cannot find a factory that satifies the requested relationship method call. So, imagine you called `UserFactory::new()->withCustomers(10)();`, but there was no `CustomerFactory`, Poser would throw this error. The solution is to create the Factory. In this case, we could call `php artisan make:poser CustomerFactory` from the terminal to automatically create the factory for us.
 
 The other time this error can crop up is if your Parent Model's relationship method name is different to the Child Model name.
-To illustrate, imaging that we have a `UserFactory` that has a `clients()` method. That method returns a has-many relationship for the `Customer` model, and you have a Poser `CustomerFactory`.
+To illustrate, imaging that we have a `UserFactory` for `User` model that has a `clients()` method. That method returns a has-many relationship for the `Customer` model, and you have a Poser `CustomerFactory`.
 
 When we call `UserFactory::new()->withClients()()`, Poser understands that you're using the `clients()` method on the `User` model, but it can't find a corresponding `ClientFactory` (because, it is in fact called `CustomerFactory`). The solution to this is to resort to standard bindings. So our updated call would be:
 

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
     },
     "autoload-dev": {
         "psr-4": {
-            "Lukeraymonddowning\\Poser\\Tests\\": "./tests"
+            "Tests\\": "./tests"
         }
     },
     "scripts": {

--- a/src/CreatePoserFactory.php
+++ b/src/CreatePoserFactory.php
@@ -2,14 +2,13 @@
 
 namespace Lukeraymonddowning\Poser;
 
-use Illuminate\Support\Str;
 use Illuminate\Console\GeneratorCommand;
-use Illuminate\Support\Facades\File;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Str;
 
 class CreatePoserFactory extends GeneratorCommand
 {
-
     protected $signature = 'make:poser {name? : The name of the Poser Factory}
                                        {--m|model= : The model that this factory is linked too}
                                        {--f|factory : Also create the Laravel database factory}';
@@ -53,11 +52,9 @@ class CreatePoserFactory extends GeneratorCommand
             ? '\\' . $this->qualifyClass($this->option('model'))
             : $expectedModelNameSpace;
 
-        $destinationDirectory = base_path() . "/" . str_replace("\\", "/", factoriesNamespace());
+        $destinationDirectory = base_path(str_replace("\\", "/", factoriesNamespace()));
 
-        if (!File::exists($destinationDirectory)) {
-            File::makeDirectory($destinationDirectory);
-        }
+        File::ensureDirectoryExists($destinationDirectory);
 
         $destination = $destinationDirectory . $factoryName . ".php";
 
@@ -74,7 +71,7 @@ class CreatePoserFactory extends GeneratorCommand
 
         File::copy($this->getStub($stubVariant), $destination);
 
-        $value = file_get_contents($destination);
+        $value = File::get($destination);
 
         $namespace = str_replace('/', '\\', factoriesNamespace());
         if (Str::endsWith($namespace, '\\')) {
@@ -95,7 +92,7 @@ class CreatePoserFactory extends GeneratorCommand
             $value
         );
 
-        file_put_contents($destination, $valueFormatted);
+        File::put($destination, $valueFormatted);
 
         $this->info($factoryName . " successfully created at " . $destination);
         $this->line("");

--- a/src/Exceptions/ArgumentsNotSatisfiableException.php
+++ b/src/Exceptions/ArgumentsNotSatisfiableException.php
@@ -3,11 +3,9 @@
 namespace Lukeraymonddowning\Poser\Exceptions;
 
 use Exception;
-use Throwable;
 
 class ArgumentsNotSatisfiableException extends Exception
 {
-
     public function __construct($callingClassName, $functionName, $relationshipMethodName, $factoryNamesChecked = [])
     {
         $message = "The relationship '" . $relationshipMethodName . "' could not be converted into a Poser Factory. You called '" . $callingClassName . "->" . $functionName . "()'. Are you sure there is a corresponding factory for " . $relationshipMethodName . "?";

--- a/src/Exceptions/ModelNotBuiltException.php
+++ b/src/Exceptions/ModelNotBuiltException.php
@@ -1,15 +1,11 @@
 <?php
 
-
 namespace Lukeraymonddowning\Poser\Exceptions;
 
-
 use Exception;
-use Throwable;
 
 class ModelNotBuiltException extends Exception
 {
-
     public function __construct($factory, $userCalled, $modelName = null)
     {
         $message = "You tried to call '" . $userCalled . "', but it doesn't exist on " .
@@ -20,5 +16,4 @@ class ModelNotBuiltException extends Exception
             class_basename($factory) . ".";
         parent::__construct($message, 0, null);
     }
-
 }

--- a/src/stubs/FactoryStub.model.txt
+++ b/src/stubs/FactoryStub.model.txt
@@ -9,6 +9,7 @@ use Lukeraymonddowning\Poser\Factory;
   * @method \Illuminate\Support\Collection|\Illuminate\Database\Eloquent\Collection|{{ ModelNamespace }}[]|{{ ModelNamespace }} create($attributes = [])
   * @method \Illuminate\Support\Collection|\Illuminate\Database\Eloquent\Collection|{{ ModelNamespace }}[]|{{ ModelNamespace }} make($attributes = [])
   */
-class {{ ClassName }} extends Factory {
+class {{ ClassName }} extends Factory
+{
     protected static $modelName = {{ ModelNamespace }}::class;
 }

--- a/src/stubs/FactoryStub.txt
+++ b/src/stubs/FactoryStub.txt
@@ -9,6 +9,7 @@ use Lukeraymonddowning\Poser\Factory;
   * @method \Illuminate\Support\Collection|\Illuminate\Database\Eloquent\Collection|{{ ModelNamespace }}[]|{{ ModelNamespace }} create($attributes = [])
   * @method \Illuminate\Support\Collection|\Illuminate\Database\Eloquent\Collection|{{ ModelNamespace }}[]|{{ ModelNamespace }} make($attributes = [])
   */
-class {{ ClassName }} extends Factory {
+class {{ ClassName }} extends Factory
+{
 
 }

--- a/tests/DatabaseFactories/AddressFactory.php
+++ b/tests/DatabaseFactories/AddressFactory.php
@@ -1,0 +1,14 @@
+<?php
+
+use Faker\Generator as Faker;
+use Illuminate\Database\Eloquent\Factory;
+use Lukeraymonddowning\Poser\Tests\Models\Address;
+use Lukeraymonddowning\Poser\Tests\Models\User;
+
+/** @var Factory $factory */
+$factory->define(Address::class, function (Faker $faker) {
+    return [
+        'line_1' => $faker->streetAddress,
+        'user_id' => factory(User::class),
+    ];
+});

--- a/tests/DatabaseFactories/CustomerFactory.php
+++ b/tests/DatabaseFactories/CustomerFactory.php
@@ -1,0 +1,14 @@
+<?php
+
+use Faker\Generator as Faker;
+use Illuminate\Database\Eloquent\Factory;
+use Lukeraymonddowning\Poser\Tests\Models\Customer;
+use Lukeraymonddowning\Poser\Tests\Models\User;
+
+/** @var Factory $factory */
+$factory->define(Customer::class, function (Faker $faker) {
+    return [
+        'name' => $faker->name,
+        'user_id' => factory(User::class),
+    ];
+});

--- a/tests/Factories/AddressFactory.php
+++ b/tests/Factories/AddressFactory.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Lukeraymonddowning\Poser\Tests\Factories;
+
+use Lukeraymonddowning\Poser\Factory;
+
+class AddressFactory extends Factory
+{
+}

--- a/tests/Factories/CustomerFactory.php
+++ b/tests/Factories/CustomerFactory.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Lukeraymonddowning\Poser\Tests\Factories;
+
+use Lukeraymonddowning\Poser\Factory;
+
+class CustomerFactory extends Factory
+{
+}

--- a/tests/Factories/UserFactory.php
+++ b/tests/Factories/UserFactory.php
@@ -6,5 +6,4 @@ use Lukeraymonddowning\Poser\Factory;
 
 class UserFactory extends Factory
 {
-
 }

--- a/tests/Models/Address.php
+++ b/tests/Models/Address.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Lukeraymonddowning\Poser\Tests\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class Address extends Model
+{
+}

--- a/tests/Models/Customer.php
+++ b/tests/Models/Customer.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Lukeraymonddowning\Poser\Tests\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class Customer extends Model
+{
+    public function user()
+    {
+        return $this->belongsTo(User::class);
+    }
+}

--- a/tests/Models/User.php
+++ b/tests/Models/User.php
@@ -6,5 +6,13 @@ use Illuminate\Database\Eloquent\Model;
 
 class User extends Model
 {
+    public function address()
+    {
+        return $this->hasOne(Address::class);
+    }
 
+    public function customers()
+    {
+        return $this->hasMany(Customer::class);
+    }
 }

--- a/tests/Models/User.php
+++ b/tests/Models/User.php
@@ -15,4 +15,9 @@ class User extends Model
     {
         return $this->hasMany(Customer::class);
     }
+
+    public function profile()
+    {
+        return $this->hasOne(UserProfile::class);
+    }
 }

--- a/tests/Models/UserProfile.php
+++ b/tests/Models/UserProfile.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Lukeraymonddowning\Poser\Tests\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class UserProfile extends Model
+{
+}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -44,6 +44,7 @@ class TestCase extends Orchestra
         $app['config']->set('app.key', '6rE9Nz59bGRbeMATftriyQjrpF7DcOQm');
         $app['config']->set('poser.models_namespace', 'Lukeraymonddowning\\Poser\\Tests\\Models\\');
         $app['config']->set('poser.factories_namespace', 'Lukeraymonddowning\\Poser\\Tests\\Factories\\');
+        $app->setBasePath(realpath(__DIR__ . '/../'));
     }
 
     /**

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -51,16 +51,37 @@ class TestCase extends Orchestra
      */
     protected function createTables()
     {
-        Schema::create(
-            'users',
-            function (Blueprint $table) {
-                $table->increments('id');
-                $table->string('name');
-                $table->string('email');
-                $table->dateTime('email_verified_at')->nullable();
-                $table->boolean('active');
-                $table->timestamps();
-            }
-        );
+        Schema::create('users', function (Blueprint $table) {
+            $table->increments('id');
+            $table->string('name');
+            $table->string('email');
+            $table->dateTime('email_verified_at')->nullable();
+            $table->boolean('active');
+            $table->timestamps();
+        });
+
+        Schema::create('addresses', function (Blueprint $table) {
+            $table->increments('id');
+            $table->string('line_1');
+            $table->unsignedInteger('user_id');
+            $table->timestamps();
+
+            $table->foreign('user_id')
+                ->references('id')
+                ->on('users')
+                ->onDelete('cascade');
+        });
+
+        Schema::create('customers', function (Blueprint $table) {
+            $table->increments('id');
+            $table->string('name');
+            $table->unsignedInteger('user_id');
+            $table->timestamps();
+
+            $table->foreign('user_id')
+                ->references('id')
+                ->on('users')
+                ->onDelete('cascade');
+        });
     }
 }

--- a/tests/Unit/CreatePoserFactoryCommandTest.php
+++ b/tests/Unit/CreatePoserFactoryCommandTest.php
@@ -71,9 +71,4 @@ class CreatePoserFactoryCommandTest extends TestCase
         $this->assertStringNotContainsString('{{ ClassName }}', $fileContents);
         $this->assertStringContainsString('class AuthorFactory extends Factory', $fileContents);
     }
-
-    /** @test */
-//    public function it_creates_database_factory()
-//    {
-////        $spy = $this->spy(FactoryMakeCommand::class);
 }

--- a/tests/Unit/CreatePoserFactoryCommandTest.php
+++ b/tests/Unit/CreatePoserFactoryCommandTest.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Tests\Unit;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\File;
+use Lukeraymonddowning\Poser\Tests\TestCase;
+
+class CreatePoserFactoryCommandTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /** @var string */
+    private $newFactoriesDirectory;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->newFactoriesDirectory = str_replace(
+            '\\',
+            '/',
+            base_path('Lukeraymonddowning\\Poser\\Tests\\Factories\\')
+        );
+
+        File::deleteDirectory(base_path('Lukeraymonddowning'));
+    }
+
+    /** @test */
+    public function it_creates_a_poser_factory_and_fills_up_wildcards()
+    {
+        $this->assertFalse(File::exists($this->newFactoriesDirectory . 'BookFactory.php'));
+
+        $this->artisan('make:poser', ['name' => 'BookFactory']);
+
+        $this->assertTrue(File::exists($this->newFactoriesDirectory . 'BookFactory.php'));
+        $fileContents = File::get($this->newFactoriesDirectory . 'BookFactory.php');
+
+        $this->assertStringNotContainsString('{{ Namespace }}', $fileContents);
+        $this->assertStringContainsString('namespace Lukeraymonddowning\Poser\Tests\Factories;', $fileContents);
+
+        $this->assertStringNotContainsString('{{ ModelNamespace }}', $fileContents);
+        $this->assertStringContainsString('\Lukeraymonddowning\Poser\Tests\Models\Book[]', $fileContents);
+
+        $this->assertStringNotContainsString('{{ ClassName }}', $fileContents);
+        $this->assertStringContainsString('class BookFactory extends Factory', $fileContents);
+    }
+}

--- a/tests/Unit/CreatePoserFactoryCommandTest.php
+++ b/tests/Unit/CreatePoserFactoryCommandTest.php
@@ -17,6 +17,8 @@ class CreatePoserFactoryCommandTest extends TestCase
     {
         parent::setUp();
 
+        $this->app->setBasePath(realpath(__DIR__ . '/../storage'));
+
         $this->newFactoriesDirectory = str_replace(
             '\\',
             '/',
@@ -45,4 +47,25 @@ class CreatePoserFactoryCommandTest extends TestCase
         $this->assertStringNotContainsString('{{ ClassName }}', $fileContents);
         $this->assertStringContainsString('class BookFactory extends Factory', $fileContents);
     }
+
+    /** @test */
+    public function it_fills_up_correct_namespaces()
+    {
+        $this->assertFalse(File::exists($this->newFactoriesDirectory . 'AuthorFactory.php'));
+
+        $this->artisan('make:poser', [
+            'name' => 'AuthorFactory',
+            '--model' => '\App\Models\User'
+        ]);
+
+        $this->assertTrue(File::exists($this->newFactoriesDirectory . 'AuthorFactory.php'));
+        $fileContents = File::get($this->newFactoriesDirectory . 'AuthorFactory.php');
+
+        $this->markTestSkipped("To be continued...");
+    }
+
+    /** @test */
+//    public function it_creates_database_factory()
+//    {
+////        $spy = $this->spy(FactoryMakeCommand::class);
 }

--- a/tests/Unit/CreatePoserFactoryCommandTest.php
+++ b/tests/Unit/CreatePoserFactoryCommandTest.php
@@ -18,6 +18,7 @@ class CreatePoserFactoryCommandTest extends TestCase
         parent::setUp();
 
         $this->app->setBasePath(realpath(__DIR__ . '/../storage'));
+        $this->app['config']->set('poser.models_namespace', '\\App\\Models\\');
 
         $this->newFactoriesDirectory = str_replace(
             '\\',
@@ -42,26 +43,33 @@ class CreatePoserFactoryCommandTest extends TestCase
         $this->assertStringContainsString('namespace Lukeraymonddowning\Poser\Tests\Factories;', $fileContents);
 
         $this->assertStringNotContainsString('{{ ModelNamespace }}', $fileContents);
-        $this->assertStringContainsString('\Lukeraymonddowning\Poser\Tests\Models\Book[]', $fileContents);
+        $this->assertStringContainsString('\App\Models\Book[]', $fileContents);
 
         $this->assertStringNotContainsString('{{ ClassName }}', $fileContents);
         $this->assertStringContainsString('class BookFactory extends Factory', $fileContents);
     }
 
     /** @test */
-    public function it_fills_up_correct_namespaces()
+    public function it_creates_a_poser_factory_for_a_model_with_custom_namespace_and_fills_up_wildcards()
     {
         $this->assertFalse(File::exists($this->newFactoriesDirectory . 'AuthorFactory.php'));
 
         $this->artisan('make:poser', [
             'name' => 'AuthorFactory',
-            '--model' => '\App\Models\User'
+            '--model' => '\App\Really\Different\ModelsNamespace\User'
         ]);
 
         $this->assertTrue(File::exists($this->newFactoriesDirectory . 'AuthorFactory.php'));
         $fileContents = File::get($this->newFactoriesDirectory . 'AuthorFactory.php');
 
-        $this->markTestSkipped("To be continued...");
+        $this->assertStringNotContainsString('{{ Namespace }}', $fileContents);
+        $this->assertStringContainsString('namespace Lukeraymonddowning\Poser\Tests\Factories;', $fileContents);
+
+        $this->assertStringNotContainsString('{{ ModelNamespace }}', $fileContents);
+        $this->assertStringContainsString('\App\Really\Different\ModelsNamespace\User[]', $fileContents);
+
+        $this->assertStringNotContainsString('{{ ClassName }}', $fileContents);
+        $this->assertStringContainsString('class AuthorFactory extends Factory', $fileContents);
     }
 
     /** @test */

--- a/tests/Unit/FactoryExceptionsTest.php
+++ b/tests/Unit/FactoryExceptionsTest.php
@@ -23,6 +23,6 @@ class FactoryExceptionsTest extends TestCase
     {
         $this->expectException(ArgumentsNotSatisfiableException::class);
 
-        dump(UserFactory::new()->withProfile()->create());
+        UserFactory::new()->withProfile()->create();
     }
 }

--- a/tests/Unit/FactoryExceptionsTest.php
+++ b/tests/Unit/FactoryExceptionsTest.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Lukeraymonddowning\Poser\Tests;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Lukeraymonddowning\Poser\Exceptions\ArgumentsNotSatisfiableException;
+use Lukeraymonddowning\Poser\Tests\Factories\UserFactory;
+
+class FactoryExceptionsTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /** @test */
+    public function it_throws_an_exception_when_unknown_relationship_is_used()
+    {
+        $this->expectException(ArgumentsNotSatisfiableException::class);
+
+        UserFactory::new()->withPets(10)->create();
+    }
+
+    /** @test */
+    public function it_throws_an_exception_when_calling_relationship_with_different_factory_name()
+    {
+        $this->expectException(ArgumentsNotSatisfiableException::class);
+
+        dump(UserFactory::new()->withProfile()->create());
+    }
+}

--- a/tests/Unit/FactoryTest.php
+++ b/tests/Unit/FactoryTest.php
@@ -9,6 +9,14 @@ use Lukeraymonddowning\Poser\Tests\TestCase;
 class FactoryTest extends TestCase
 {
     /** @test */
+    public function it_returns_a_new_instance_of_the_factory()
+    {
+        $this->assertInstanceOf(UserFactory::class, UserFactory::new());
+
+        $this->assertInstanceOf(UserFactory::class, UserFactory::times(5));
+    }
+
+    /** @test */
     public function it_creates_a_user()
     {
         $this->assertEquals(0, User::count());
@@ -63,6 +71,11 @@ class FactoryTest extends TestCase
 
         $this->assertFalse($john->active);
         $this->assertNull($john->email_verified_at);
+
+        $jane = UserFactory::new()->states('inactive', 'unverified')->create();
+
+        $this->assertFalse($jane->active);
+        $this->assertNull($jane->email_verified_at);
     }
 
     /** @test */

--- a/tests/Unit/FactoryTest.php
+++ b/tests/Unit/FactoryTest.php
@@ -2,7 +2,10 @@
 
 namespace Lukeraymonddowning\Poser\Tests\Unit;
 
+use Lukeraymonddowning\Poser\Tests\Factories\CustomerFactory;
 use Lukeraymonddowning\Poser\Tests\Factories\UserFactory;
+use Lukeraymonddowning\Poser\Tests\Models\Address;
+use Lukeraymonddowning\Poser\Tests\Models\Customer;
 use Lukeraymonddowning\Poser\Tests\Models\User;
 use Lukeraymonddowning\Poser\Tests\TestCase;
 
@@ -86,5 +89,33 @@ class FactoryTest extends TestCase
         UserFactory::new()->times(5)->create();
 
         $this->assertEquals(5, User::count());
+    }
+
+    /** @test */
+    public function it_creates_a_user_with_address()
+    {
+        $john = UserFactory::new()->withAddress()->create();
+        $this->assertInstanceOf(Address::class, $john->address);
+
+        $jack = UserFactory::new()->hasAddress()->create();
+        $this->assertInstanceOf(Address::class, $jack->address);
+
+        $jane = UserFactory::new()->withAddress(['line_1' => 'Red Square 1'])->create();
+        $this->assertEquals('Red Square 1', $jane->address->line_1);
+    }
+
+    /** @test */
+    public function it_creates_a_user_with_related_customers()
+    {
+        $john = UserFactory::new()->withCustomers()->create();
+        $this->assertCount(1, $john->customers);
+
+        $jane = UserFactory::new()->withCustomers(3)->create();
+        $this->assertCount(3, $jane->customers);
+
+        $jane = UserFactory::new()->withCustomers(2, ['name' => 'John Namesake'])->create();
+        $this->assertCount(2, $jane->customers);
+        $this->assertEquals('John Namesake', $jane->customers[0]->name);
+        $this->assertEquals('John Namesake', $jane->customers[1]->name);
     }
 }

--- a/tests/storage/.gitignore
+++ b/tests/storage/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore


### PR DESCRIPTION
New tests for:
-  `with<Relationship>()`/`for<Relationship>()` 
- `as()`/`state()` and `states()`
- `CreatePoserFactory` command.
  - Here I need an advise: I run `make:poser` command during the test and it creates a brand new factory. I could remove it in the `tearDown` method but I decided to leave it and delete in `setUp`, before the test is starting, instead. And because of that I had to add the path to `.gitignore`. What do you think about that? If you would use `Storage` instead of `File` - it could be faked then. But right now it is like this. Give me your thoughts and I'll fix it if needed.

Updated some typo-s in `README.md`
- Here I have a question. Can `ModelNotBuiltException` ever happend after you added `Automated 'create' functionality`? I couldn't make it thrown. If this is still a thing - tell me how to reproduce it and I'll add a test for that. Otherwise this you could remove the exception from the `Readme` or update the section.

