### PR TITLE
Added support for multiple pivot attributes 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 2.5.0-beta
+Added multiple attribute set support for the `withPivotAttributes()` method, similar to standard attributes in 2.4.0-beta.
+
 # 2.4.0-beta
 Sometimes, you want to specify different arguments for each model you create. For example, imagine we wanted to create 30 users, 10 called "Bob", 10 called "Barry" and 10 called "Gordon". Poser now allows that with the following syntax:
 

--- a/README.md
+++ b/README.md
@@ -373,6 +373,22 @@ public function a_user_can_have_many_roles() {
 }
 ```
 
+For instances where you would like to save different pivot data on each related model, `withPivotAttributes()` accepts
+multiple attribute sets:
+
+```php
+/** @test */
+public function a_user_can_have_many_roles() {
+    $user = UserFactory::new()->withRoles(RoleFactory::times(3)->withPivotAttributes(
+        ['expires_at' => now()->addDay()],
+        ['expires_at' => now()->addDays(2)],
+        ['expires_at' => now()->addDays(3)]
+    ))();
+
+    // ...assertions go here
+}
+``` 
+
 It is important to note that you should not use the `make()`, `create()` or `invoke()` methods on the relationship factory
 when adding pivot attributes, as Poser will have no way to access them when saving the models.
 
@@ -593,10 +609,13 @@ to the created models.
 Similar to `->state(string $state)`, but allows you to pass in multiple states that will all be applied
 to the created models.
 
-#### `->withPivotAttributes(array $attributes)`
+#### `->withPivotAttributes(...$attributes)`
 When working with Many-to-Many relationships, you may want to store data on the pivot table. You may use
 this method to do so, passing in an associative array of column names with desired values. This should
 be called on the related factory, not the root-level factory.
+
+If you would like to apply different pivot attributes to each model that will be created, you may pass as many attribute
+arrays as separate parameters as desired.
 
 #### `->afterCreating(Closure $closure)`
 Allows you to provide a hook that will be called when the given factory has created its model(s). This 

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -134,7 +134,7 @@ abstract class Factory
      *
      * @return $this
      */
-    public function withPivotAttributes(array $attributes)
+    public function withPivotAttributes(...$attributes)
     {
         $this->pivotAttributes = $attributes;
 
@@ -442,8 +442,8 @@ abstract class Factory
                 }
 
                 $models->each(
-                    function ($relatedModel) use ($model, $relationshipName, $relatedModels) {
-                        $model->{$relationshipName}()->save($relatedModel, $relatedModels->pivotAttributes ?? []);
+                    function ($relatedModel, $index) use ($model, $relationshipName, $relatedModels) {
+                        $model->{$relationshipName}()->save($relatedModel, $this->getDesiredAttributeData($relatedModels->pivotAttributes ?? [], $index));
 
                         if ($relatedModels instanceof Factory) {
                             $relatedModels->buildAllWithRelationships($relatedModel);


### PR DESCRIPTION
Added multiple attribute set support for the `withPivotAttributes()` method, similar to standard attributes in 2.4.0-beta.