### PR TITLE
Refactor broken test

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
     },
     "autoload-dev": {
         "psr-4": {
-            "Tests\\": "./tests"
+            "Lukeraymonddowning\\Poser\\Tests\\": "./tests"
         }
     },
     "scripts": {

--- a/src/CreatePoserFactory.php
+++ b/src/CreatePoserFactory.php
@@ -2,6 +2,7 @@
 
 namespace Lukeraymonddowning\Poser;
 
+use ReflectionException;
 use Illuminate\Console\GeneratorCommand;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Facades\File;
@@ -48,9 +49,22 @@ class CreatePoserFactory extends GeneratorCommand
         $this->info("Creating Poser Factory called " . $factoryName);
 
         $expectedModelNameSpace = '\\' . modelsNamespace() . Str::beforeLast($factoryName, 'Factory');
-        $linkedModelNamespace = $this->option('model')
-            ? '\\' . $this->qualifyClass($this->option('model'))
-            : $expectedModelNameSpace;
+
+        // TODO - Decide if this actually should be caught
+        if (($optionModel = $this->option('model')) !== null) {
+            try {
+                $modelReflection = new \ReflectionClass($optionModel);
+                $linkedModelNamespace = '\\' . $modelReflection->getName();
+            } catch (ReflectionException $e) {
+                $linkedModelNamespace = $expectedModelNameSpace;
+            }
+        } else {
+            $linkedModelNamespace = $expectedModelNameSpace;
+        }
+
+        // TODO - or just choose this instead
+        // $modelReflection = new \ReflectionClass($this->option('model') ?? $expectedModelNameSpace);
+        // $linkedModelNamespace = '\\' . $modelReflection->getName();
 
         $destinationDirectory = base_path(str_replace("\\", "/", factoriesNamespace()));
 

--- a/tests/Unit/CreatePoserFactoryCommandTest.php
+++ b/tests/Unit/CreatePoserFactoryCommandTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Tests\Unit;
+namespace Lukeraymonddowning\Poser\Tests\Unit;
 
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\File;
@@ -56,7 +56,7 @@ class CreatePoserFactoryCommandTest extends TestCase
 
         $this->artisan('make:poser', [
             'name' => 'AuthorFactory',
-            '--model' => '\App\Really\Different\ModelsNamespace\User'
+            '--model' => '\Lukeraymonddowning\Poser\Tests\Models\User'
         ]);
 
         $this->assertTrue(File::exists($this->newFactoriesDirectory . 'AuthorFactory.php'));
@@ -66,7 +66,7 @@ class CreatePoserFactoryCommandTest extends TestCase
         $this->assertStringContainsString('namespace Lukeraymonddowning\Poser\Tests\Factories;', $fileContents);
 
         $this->assertStringNotContainsString('{{ ModelNamespace }}', $fileContents);
-        $this->assertStringContainsString('\App\Really\Different\ModelsNamespace\User[]', $fileContents);
+        $this->assertStringContainsString('\Lukeraymonddowning\Poser\Tests\Models\User[]', $fileContents);
 
         $this->assertStringNotContainsString('{{ ClassName }}', $fileContents);
         $this->assertStringContainsString('class AuthorFactory extends Factory', $fileContents);


### PR DESCRIPTION
Test `it_creates_a_poser_factory_for_a_model_with_custom_namespace_and_fills_up_wildcards` fails out of the box with error:
```
ErrorException: file_get_contents(/pathtoroot/tests/storage/composer.json): failed to open stream: No such file or directory
```
The cause is L52 of `src/CreatePoserFactory.php`, where the inner calls look for a non-existing `composer.json` file at `tests/storage/composer.json`.

I've done some fixes to namespacing on the test, it now references an existing Model with a custom path (previously it didn't exist), and proposed a couple fixes to the source itself at `src/CreatePoserFactory.php`

The 2 proposals are essentially based on whether or not an error should be thrown if the model can't actually be found. 
The first (at L54) proposes a situation similar to what already exists, whereas the second (at L65) would throw an exception if the model can't actually be found.

Personally I prefer the second, since I'd expect an error when there's no existing model, just thought it best to give options. 