### PR TITLE
Case sensitivity (and some other tests)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,8 @@
         }
     ],
     "require": {
-        "illuminate/support": "^6.0|^7.0"
+        "illuminate/support": "^6.0|^7.0",
+        "haydenpierce/class-finder": "^0.4.0"
     },
     "require-dev": {
         "orchestra/testbench": "^4.0",

--- a/src/CreatePoserFactory.php
+++ b/src/CreatePoserFactory.php
@@ -121,7 +121,7 @@ class CreatePoserFactory extends GeneratorCommand
     {
         $namespace = trim(modelsNamespace(), '\\');
         $models = ClassFinder::getClassesInNamespace($namespace);
-        if (!\is_array($models) || empty($models)) {
+        if (empty($models)) {
             $this->error('Couldn\'t find any classes at the configured namespace');
             return 1;
         }

--- a/src/CreatePoserFactory.php
+++ b/src/CreatePoserFactory.php
@@ -59,7 +59,7 @@ class CreatePoserFactory extends GeneratorCommand
             return 1;
         }
 
-        $destinationDirectory = base_path(factoriesDirectory());
+        $destinationDirectory = base_path(factoriesLocation());
 
         File::ensureDirectoryExists($destinationDirectory);
 
@@ -141,7 +141,7 @@ class CreatePoserFactory extends GeneratorCommand
                 }
             )->filter(
                 function ($factoryName) {
-                    $file = base_path(factoriesDirectory()) . $factoryName . '.php';
+                    $file = base_path(factoriesLocation()) . $factoryName . '.php';
                     return !file_exists($file);
                 }
             )->each(

--- a/src/CreatePoserFactory.php
+++ b/src/CreatePoserFactory.php
@@ -3,7 +3,6 @@
 namespace Lukeraymonddowning\Poser;
 
 use HaydenPierce\ClassFinder\ClassFinder;
-use ReflectionException;
 use Illuminate\Console\GeneratorCommand;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Facades\File;
@@ -49,21 +48,8 @@ class CreatePoserFactory extends GeneratorCommand
 
         $expectedModelNameSpace = '\\' . modelsNamespace() . Str::beforeLast($factoryName, 'Factory');
 
-        // TODO - Decide if this actually should be caught
-        if (($optionModel = $this->option('model')) !== null) {
-            try {
-                $modelReflection = new \ReflectionClass($optionModel);
-                $linkedModelNamespace = '\\' . $modelReflection->getName();
-            } catch (ReflectionException $e) {
-                $linkedModelNamespace = $expectedModelNameSpace;
-            }
-        } else {
-            $linkedModelNamespace = $expectedModelNameSpace;
-        }
-
-        // TODO - or just choose this instead
-        // $modelReflection = new \ReflectionClass($this->option('model') ?? $expectedModelNameSpace);
-        // $linkedModelNamespace = '\\' . $modelReflection->getName();
+        $modelReflection = new \ReflectionClass($this->option('model') ?? $expectedModelNameSpace);
+        $linkedModelNamespace = '\\' . $modelReflection->getName();
 
         $destinationDirectory = base_path(factoriesDirectory());
 

--- a/src/CreatePoserFactory.php
+++ b/src/CreatePoserFactory.php
@@ -7,6 +7,7 @@ use Illuminate\Console\GeneratorCommand;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Facades\File;
 use Illuminate\Support\Str;
+use ReflectionException;
 
 class CreatePoserFactory extends GeneratorCommand
 {
@@ -48,8 +49,15 @@ class CreatePoserFactory extends GeneratorCommand
 
         $expectedModelNameSpace = '\\' . modelsNamespace() . Str::beforeLast($factoryName, 'Factory');
 
-        $modelReflection = new \ReflectionClass($this->option('model') ?? $expectedModelNameSpace);
-        $linkedModelNamespace = '\\' . $modelReflection->getName();
+        try {
+            $modelReflection = new \ReflectionClass($this->option('model') ?? $expectedModelNameSpace);
+            $linkedModelNamespace = '\\' . $modelReflection->getName();
+        } catch (ReflectionException $e) {
+            $this->error('Could not locate '
+            . ($this->option('model') ?? $expectedModelNameSpace)
+            . ' at configured namespace');
+            return 1;
+        }
 
         $destinationDirectory = base_path(factoriesDirectory());
 

--- a/src/config/poser.php
+++ b/src/config/poser.php
@@ -38,6 +38,6 @@ return [
     | you may override this with the path of your Factory namespace.
     |
     */
-    "factories_directory" => "tests/Factories/"
+    "factories_location" => "tests/Factories/"
 
 ];

--- a/src/config/poser.php
+++ b/src/config/poser.php
@@ -26,6 +26,18 @@ return [
     |
     */
 
-    "factories_namespace" => "Tests\\Factories\\"
+    "factories_namespace" => "Tests\\Factories\\",
+
+    /*
+    |--------------------------------------------------------------------------
+    | Factories Directory
+    |--------------------------------------------------------------------------
+    |
+    | By default, Poser will place generated files in the 'tests/Factories' directory for your Factory classes.
+    | If you have your Factories in a different location (eg: 'tests/Models/Factories'),
+    | you may override this with the path of your Factory namespace.
+    |
+    */
+    "factories_directory" => "tests/Factories/"
 
 ];

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -10,13 +10,13 @@ if (!function_exists('modelsNamespace')) {
 if (!function_exists('factoriesNamespace')) {
     function factoriesNamespace()
     {
-        return config('poser.factories_namespace', "Tests\\Factories\\");
+        return config('poser.factories_namespace', config('poser.models_directory', "Tests\\Factories\\"));
     }
 }
 
 if (!function_exists('factoriesDirectory')) {
     function factoriesDirectory()
     {
-        return config('poser.factories_directory', "tests/Factories/");
+        return config('poser.factories_location', "tests/Factories/");
     }
 }

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -10,7 +10,7 @@ if (!function_exists('modelsNamespace')) {
 if (!function_exists('factoriesNamespace')) {
     function factoriesNamespace()
     {
-        return config('poser.factories_namespace', config('poser.models_directory', "Tests\\Factories\\"));
+        return config('poser.factories_namespace', config('poser.factories_directory', "Tests\\Factories\\"));
     }
 }
 

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -14,8 +14,8 @@ if (!function_exists('factoriesNamespace')) {
     }
 }
 
-if (!function_exists('factoriesDirectory')) {
-    function factoriesDirectory()
+if (!function_exists('factoriesLocation')) {
+    function factoriesLocation()
     {
         return config('poser.factories_location', "tests/Factories/");
     }

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -10,6 +10,13 @@ if (!function_exists('modelsNamespace')) {
 if (!function_exists('factoriesNamespace')) {
     function factoriesNamespace()
     {
-        return config('poser.factories_namespace', config('poser.factories_directory', "Tests\\Factories\\"));
+        return config('poser.factories_namespace', "Tests\\Factories\\");
+    }
+}
+
+if (!function_exists('factoriesDirectory')) {
+    function factoriesDirectory()
+    {
+        return config('poser.factories_directory', "tests/Factories/");
     }
 }

--- a/tests/Unit/CreatePoserFactoryCommandTest.php
+++ b/tests/Unit/CreatePoserFactoryCommandTest.php
@@ -29,12 +29,16 @@ class CreatePoserFactoryCommandTest extends TestCase
     /** @test */
     public function it_creates_a_poser_factory_and_fills_up_wildcards()
     {
+        $this->artisan('make:poser', ['name' => 'NotARealClass'])->assertExitCode(1);
+
         $this->assertFalse(File::exists($this->newFactoriesDirectory . 'UserFactory.php'));
 
-        $this->artisan('make:poser', ['name' => 'UserFactory']);
+        $this->artisan('make:poser', ['name' => 'UserFactory'])->assertExitCode(0);
 
         $this->assertTrue(File::exists($this->newFactoriesDirectory . 'UserFactory.php'));
         $fileContents = File::get($this->newFactoriesDirectory . 'UserFactory.php');
+
+        $this->artisan('make:poser', ['name' => 'UserFactory'])->assertExitCode(2);
 
         $this->assertStringNotContainsString('{{ Namespace }}', $fileContents);
         $this->assertStringContainsString('namespace Lukeraymonddowning\Poser\Tests\Factories;', $fileContents);
@@ -49,6 +53,11 @@ class CreatePoserFactoryCommandTest extends TestCase
     /** @test */
     public function it_creates_a_poser_factory_for_a_model_with_custom_namespace_and_fills_up_wildcards()
     {
+        $this->artisan('make:poser', [
+            'name' => 'Name',
+            '--model' => '\App\NotARealClass'
+        ])->assertExitCode(1);
+
         $this->assertFalse(File::exists($this->newFactoriesDirectory . 'AuthorFactory.php'));
 
         $this->artisan('make:poser', [
@@ -58,6 +67,11 @@ class CreatePoserFactoryCommandTest extends TestCase
 
         $this->assertTrue(File::exists($this->newFactoriesDirectory . 'AuthorFactory.php'));
         $fileContents = File::get($this->newFactoriesDirectory . 'AuthorFactory.php');
+
+        $this->artisan('make:poser', [
+            'name' => 'AuthorFactory',
+            '--model' => '\Lukeraymonddowning\Poser\Tests\Models\Address'
+        ])->assertExitCode(2);
 
         $this->assertStringNotContainsString('{{ Namespace }}', $fileContents);
         $this->assertStringContainsString('namespace Lukeraymonddowning\Poser\Tests\Factories;', $fileContents);

--- a/tests/Unit/CreatePoserFactoryCommandTest.php
+++ b/tests/Unit/CreatePoserFactoryCommandTest.php
@@ -18,7 +18,7 @@ class CreatePoserFactoryCommandTest extends TestCase
         parent::setUp();
 
         $this->app->setBasePath(realpath(__DIR__ . '/../storage'));
-        $this->app['config']->set('poser.models_namespace', '\\App\\Models\\');
+        $this->app['config']->set('poser.models_namespace', 'Lukeraymonddowning\\Poser\\Tests\\Models\\');
         $this->app['config']->set('poser.factories_directory', 'NewTestsDir/Factories/');
 
         $this->newFactoriesDirectory = base_path(config('poser.factories_directory'));
@@ -29,21 +29,21 @@ class CreatePoserFactoryCommandTest extends TestCase
     /** @test */
     public function it_creates_a_poser_factory_and_fills_up_wildcards()
     {
-        $this->assertFalse(File::exists($this->newFactoriesDirectory . 'BookFactory.php'));
+        $this->assertFalse(File::exists($this->newFactoriesDirectory . 'UserFactory.php'));
 
-        $this->artisan('make:poser', ['name' => 'BookFactory']);
+        $this->artisan('make:poser', ['name' => 'UserFactory']);
 
-        $this->assertTrue(File::exists($this->newFactoriesDirectory . 'BookFactory.php'));
-        $fileContents = File::get($this->newFactoriesDirectory . 'BookFactory.php');
+        $this->assertTrue(File::exists($this->newFactoriesDirectory . 'UserFactory.php'));
+        $fileContents = File::get($this->newFactoriesDirectory . 'UserFactory.php');
 
         $this->assertStringNotContainsString('{{ Namespace }}', $fileContents);
         $this->assertStringContainsString('namespace Lukeraymonddowning\Poser\Tests\Factories;', $fileContents);
 
         $this->assertStringNotContainsString('{{ ModelNamespace }}', $fileContents);
-        $this->assertStringContainsString('\App\Models\Book[]', $fileContents);
+        $this->assertStringContainsString('\Lukeraymonddowning\Poser\Tests\Models\User[]', $fileContents);
 
         $this->assertStringNotContainsString('{{ ClassName }}', $fileContents);
-        $this->assertStringContainsString('class BookFactory extends Factory', $fileContents);
+        $this->assertStringContainsString('class UserFactory extends Factory', $fileContents);
     }
 
     /** @test */
@@ -53,8 +53,8 @@ class CreatePoserFactoryCommandTest extends TestCase
 
         $this->artisan('make:poser', [
             'name' => 'AuthorFactory',
-            '--model' => '\Lukeraymonddowning\Poser\Tests\Models\User'
-        ]);
+            '--model' => '\Lukeraymonddowning\Poser\Tests\Models\Address'
+        ])->assertExitCode(0);
 
         $this->assertTrue(File::exists($this->newFactoriesDirectory . 'AuthorFactory.php'));
         $fileContents = File::get($this->newFactoriesDirectory . 'AuthorFactory.php');
@@ -63,7 +63,7 @@ class CreatePoserFactoryCommandTest extends TestCase
         $this->assertStringContainsString('namespace Lukeraymonddowning\Poser\Tests\Factories;', $fileContents);
 
         $this->assertStringNotContainsString('{{ ModelNamespace }}', $fileContents);
-        $this->assertStringContainsString('\Lukeraymonddowning\Poser\Tests\Models\User[]', $fileContents);
+        $this->assertStringContainsString('\Lukeraymonddowning\Poser\Tests\Models\Address[]', $fileContents);
 
         $this->assertStringNotContainsString('{{ ClassName }}', $fileContents);
         $this->assertStringContainsString('class AuthorFactory extends Factory', $fileContents);
@@ -72,15 +72,15 @@ class CreatePoserFactoryCommandTest extends TestCase
     /** @test */
     public function it_creates_multiple_poser_factories()
     {
-        $this->artisan('make:poser')->assertExitCode(1); //Couldn't find any classes at the namespace
-
         $oldNamespace = config('poser.models_namespace');
-        $this->app['config']->set('poser.models_namespace', 'Lukeraymonddowning\\Poser\\Tests\\Models\\');
+        $this->app['config']->set('poser.models_namespace', 'App\\Models\\');
+        $this->artisan('make:poser')->assertExitCode(1); //Couldn't find any classes at the namespace
+        $this->app['config']->set('poser.models_namespace', $oldNamespace);
 
-        $this->assertEquals(0, count(File::glob($this->newFactoriesDirectory . '*.php')));
+        $filesBeforeRun = count(File::glob($this->newFactoriesDirectory . '*.php'));
 
         $this->artisan('make:poser')->assertExitCode(0); //Models created, success response
-        $this->assertGreaterThan(1, count(File::glob($this->newFactoriesDirectory . '*.php')));
+        $this->assertGreaterThan($filesBeforeRun, count(File::glob($this->newFactoriesDirectory . '*.php')));
 
         //Models existed but didn't create any Factories since they already existed
         $this->artisan('make:poser')->assertExitCode(2);

--- a/tests/Unit/CreatePoserFactoryCommandTest.php
+++ b/tests/Unit/CreatePoserFactoryCommandTest.php
@@ -11,7 +11,7 @@ class CreatePoserFactoryCommandTest extends TestCase
     use RefreshDatabase;
 
     /** @var string */
-    private $newFactoriesDirectory;
+    private $newFactoriesLocation;
 
     protected function setUp(): void
     {
@@ -21,7 +21,7 @@ class CreatePoserFactoryCommandTest extends TestCase
         $this->app['config']->set('poser.models_namespace', 'Lukeraymonddowning\\Poser\\Tests\\Models\\');
         $this->app['config']->set('poser.factories_location', 'NewTestsDir/Factories/');
 
-        $this->newFactoriesDirectory = base_path(config('poser.factories_location'));
+        $this->newFactoriesLocation = base_path(config('poser.factories_location'));
 
         File::deleteDirectory(base_path('NewTestsDir'));
     }
@@ -31,12 +31,12 @@ class CreatePoserFactoryCommandTest extends TestCase
     {
         $this->artisan('make:poser', ['name' => 'NotARealClass'])->assertExitCode(1);
 
-        $this->assertFalse(File::exists($this->newFactoriesDirectory . 'UserFactory.php'));
+        $this->assertFalse(File::exists($this->newFactoriesLocation . 'UserFactory.php'));
 
         $this->artisan('make:poser', ['name' => 'UserFactory'])->assertExitCode(0);
 
-        $this->assertTrue(File::exists($this->newFactoriesDirectory . 'UserFactory.php'));
-        $fileContents = File::get($this->newFactoriesDirectory . 'UserFactory.php');
+        $this->assertTrue(File::exists($this->newFactoriesLocation . 'UserFactory.php'));
+        $fileContents = File::get($this->newFactoriesLocation . 'UserFactory.php');
 
         $this->artisan('make:poser', ['name' => 'UserFactory'])->assertExitCode(2);
 
@@ -58,15 +58,15 @@ class CreatePoserFactoryCommandTest extends TestCase
             '--model' => '\App\NotARealClass'
         ])->assertExitCode(1);
 
-        $this->assertFalse(File::exists($this->newFactoriesDirectory . 'AuthorFactory.php'));
+        $this->assertFalse(File::exists($this->newFactoriesLocation . 'AuthorFactory.php'));
 
         $this->artisan('make:poser', [
             'name' => 'AuthorFactory',
             '--model' => '\Lukeraymonddowning\Poser\Tests\Models\Address'
         ])->assertExitCode(0);
 
-        $this->assertTrue(File::exists($this->newFactoriesDirectory . 'AuthorFactory.php'));
-        $fileContents = File::get($this->newFactoriesDirectory . 'AuthorFactory.php');
+        $this->assertTrue(File::exists($this->newFactoriesLocation . 'AuthorFactory.php'));
+        $fileContents = File::get($this->newFactoriesLocation . 'AuthorFactory.php');
 
         $this->artisan('make:poser', [
             'name' => 'AuthorFactory',
@@ -91,10 +91,10 @@ class CreatePoserFactoryCommandTest extends TestCase
         $this->artisan('make:poser')->assertExitCode(1); //Couldn't find any classes at the namespace
         $this->app['config']->set('poser.models_namespace', $oldNamespace);
 
-        $filesBeforeRun = count(File::glob($this->newFactoriesDirectory . '*.php'));
+        $filesBeforeRun = count(File::glob($this->newFactoriesLocation . '*.php'));
 
         $this->artisan('make:poser')->assertExitCode(0); //Models created, success response
-        $this->assertGreaterThan($filesBeforeRun, count(File::glob($this->newFactoriesDirectory . '*.php')));
+        $this->assertGreaterThan($filesBeforeRun, count(File::glob($this->newFactoriesLocation . '*.php')));
 
         //Models existed but didn't create any Factories since they already existed
         $this->artisan('make:poser')->assertExitCode(2);
@@ -102,8 +102,8 @@ class CreatePoserFactoryCommandTest extends TestCase
         $this->app['config']->set('poser.models_namespace', $oldNamespace);
 
         //Run the rest of the file checks
-        $this->assertTrue(File::exists($this->newFactoriesDirectory . 'UserProfileFactory.php'));
-        $fileContents = File::get($this->newFactoriesDirectory . 'UserProfileFactory.php');
+        $this->assertTrue(File::exists($this->newFactoriesLocation . 'UserProfileFactory.php'));
+        $fileContents = File::get($this->newFactoriesLocation . 'UserProfileFactory.php');
 
         $this->assertStringNotContainsString('{{ Namespace }}', $fileContents);
         $this->assertStringContainsString('namespace Lukeraymonddowning\Poser\Tests\Factories;', $fileContents);

--- a/tests/Unit/CreatePoserFactoryCommandTest.php
+++ b/tests/Unit/CreatePoserFactoryCommandTest.php
@@ -19,9 +19,9 @@ class CreatePoserFactoryCommandTest extends TestCase
 
         $this->app->setBasePath(realpath(__DIR__ . '/../storage'));
         $this->app['config']->set('poser.models_namespace', 'Lukeraymonddowning\\Poser\\Tests\\Models\\');
-        $this->app['config']->set('poser.factories_directory', 'NewTestsDir/Factories/');
+        $this->app['config']->set('poser.factories_location', 'NewTestsDir/Factories/');
 
-        $this->newFactoriesDirectory = base_path(config('poser.factories_directory'));
+        $this->newFactoriesDirectory = base_path(config('poser.factories_location'));
 
         File::deleteDirectory(base_path('NewTestsDir'));
     }


### PR DESCRIPTION
This should fix the case sensitivity issue for anyone using Linux and I fixed any other little issues I came across along the way.

I used a lib, `haydenpierce/class-finder`, to locate the classes at the model namespace, and added a seperate config option (factories_directory) for the Factories location, default being Laravel's default of course.

I also chose the second option from PR #51 as you requested, I also wrapped it in a try/catch so it can fail gracefully. On that note I also added in some tests to assert the exit code from Artisan, since it wasn't giving any exit codes originally.

Exit codes:
0 = Successful
1 = Model doesn't exist
2 = Factory already exists

Also I added a bunch of tests for the `make:poser` bulk command. I'd suggest at some point refactoring the success response in this case since it means the 
>Please consider starring the repo at https://github.com/lukeraymonddowning/poser

gets repeated for each model. 