### PR TITLE
Adds a Relationship class to better handle data in relationships

### DIFF
--- a/src/Factory.php
+++ b/src/Factory.php
@@ -562,29 +562,25 @@ abstract class Factory
     {
         $this->withRelationships->each(
             function (Relationship $relationship) use ($model) {
-                $models = $relationship->getData() instanceof Factory ? $relationship->getData()->make() : $relationship->getData();
-
-                if ($models instanceof Model) {
-                    $models = collect([$models]);
-                }
-
+                $models = $relationship->buildModels();
                 $models->each(
                     function ($relatedModel, $index) use ($model, $relationship) {
                         $model->{$relationship->getFunctionName()}()->save(
                             $relatedModel,
                             $this->getDesiredAttributeData(
-                                isset($relationship->getData()->pivotAttributes) ? $relationship->getData()->pivotAttributes : [],
+                                isset($relationship->getData()->pivotAttributes) ?
+                                    $relationship->getData()->pivotAttributes : [],
                                 $index
                             )
                         );
 
-                        if ($relationship->getData() instanceof Factory) {
+                        if ($relationship->dataIsFactory()) {
                             $relationship->getData()->buildAllWithRelationships($relatedModel);
                         }
                     }
                 );
 
-                if ($relationship->getData() instanceof Factory) {
+                if ($relationship->dataIsFactory()) {
                     $relationship->getData()->processAfterCreating($models, $model);
                 }
             }
@@ -606,8 +602,7 @@ abstract class Factory
             function (Relationship $relationship) use ($model) {
                 $cachedLocation = "PoserForRelationship_" . $relationship->getFunctionName();
                 if (!isset($this->$cachedLocation)) {
-                    $this->$cachedLocation = $relationship->getData() instanceof Factory ? $relationship->getData()->create(
-                    ) : $relationship->getData();
+                    $this->$cachedLocation = $relationship->createModels();
                 }
                 $model->{$relationship->getFunctionName()}()->associate($this->$cachedLocation);
             }

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -7,6 +7,7 @@ use Closure;
 use ReflectionClass;
 use ReflectionMethod;
 use Mockery\Exception;
+use ReflectionException;
 use Illuminate\Support\Str;
 use Illuminate\Support\Collection;
 use Illuminate\Database\Eloquent\Model;
@@ -341,7 +342,7 @@ abstract class Factory
     protected function handleWithRelationship(string $functionName, array $arguments)
     {
         return Str::startsWith($functionName, ['with', 'has']) ?
-            (bool) $this->addRelationship($this->withRelationships, $functionName, $arguments) :
+            (bool)$this->addRelationship($this->withRelationships, $functionName, $arguments) :
             false;
     }
 
@@ -355,19 +356,21 @@ abstract class Factory
     protected function handleForRelationship(string $functionName, array $arguments)
     {
         return Str::startsWith($functionName, 'for') ?
-            (bool) $this->addRelationship($this->forRelationships, $functionName, $arguments) :
+            (bool)$this->addRelationship($this->forRelationships, $functionName, $arguments) :
             false;
     }
 
     protected function addRelationship(Collection $relationshipArray, string $functionName, array $arguments)
     {
-        return $relationshipArray->push([
-            $this->getRelationshipMethodName($functionName),
-            $this->buildRelationshipData(
-                $functionName,
-                $arguments
+        return $relationshipArray->push(
+            new Relationship(
+                $this->getRelationshipMethodName($functionName),
+                $this->buildRelationshipData(
+                    $functionName,
+                    $arguments
+                )
             )
-        ]);
+        );
     }
 
     protected function handleDefaultRelationships()
@@ -411,7 +414,7 @@ abstract class Factory
     }
 
     /**
-     * @param ReflectionClass $mirror
+     * @throws ReflectionException
      * @return Collection
      */
     protected function getDefaultMethods(): Collection

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -400,8 +400,8 @@ abstract class Factory
                 ->filter(
                     function ($relationships) use ($relationshipMethodName) {
                         return $relationships->filter(
-                            function ($withRelationship) use ($relationshipMethodName) {
-                                return $withRelationship[0] == $relationshipMethodName;
+                            function (Relationship $withRelationship) use ($relationshipMethodName) {
+                                return $withRelationship->getFunctionName() == $relationshipMethodName;
                             }
                         )->isNotEmpty();
                     }
@@ -561,33 +561,31 @@ abstract class Factory
     protected function buildAllWithRelationships($model)
     {
         $this->withRelationships->each(
-            function ($data) use ($model) {
-                $relationshipName = $data[0];
-                $relatedModels = $data[1];
-                $models = $relatedModels instanceof Factory ? $relatedModels->make() : $relatedModels;
+            function (Relationship $relationship) use ($model) {
+                $models = $relationship->getData() instanceof Factory ? $relationship->getData()->make() : $relationship->getData();
 
                 if ($models instanceof Model) {
                     $models = collect([$models]);
                 }
 
                 $models->each(
-                    function ($relatedModel, $index) use ($model, $relationshipName, $relatedModels) {
-                        $model->{$relationshipName}()->save(
+                    function ($relatedModel, $index) use ($model, $relationship) {
+                        $model->{$relationship->getFunctionName()}()->save(
                             $relatedModel,
                             $this->getDesiredAttributeData(
-                                isset($relatedModels->pivotAttributes) ? $relatedModels->pivotAttributes : [],
+                                isset($relationship->getData()->pivotAttributes) ? $relationship->getData()->pivotAttributes : [],
                                 $index
                             )
                         );
 
-                        if ($relatedModels instanceof Factory) {
-                            $relatedModels->buildAllWithRelationships($relatedModel);
+                        if ($relationship->getData() instanceof Factory) {
+                            $relationship->getData()->buildAllWithRelationships($relatedModel);
                         }
                     }
                 );
 
-                if ($relatedModels instanceof Factory) {
-                    $relatedModels->processAfterCreating($models, $model);
+                if ($relationship->getData() instanceof Factory) {
+                    $relationship->getData()->processAfterCreating($models, $model);
                 }
             }
         );
@@ -605,13 +603,13 @@ abstract class Factory
     protected function buildAllForRelationships(Model $model)
     {
         $this->forRelationships->each(
-            function ($data) use ($model) {
-                $relationshipName = $data[0];
-                $cachedLocation = "PoserForRelationship_" . $relationshipName;
+            function (Relationship $relationship) use ($model) {
+                $cachedLocation = "PoserForRelationship_" . $relationship->getFunctionName();
                 if (!isset($this->$cachedLocation)) {
-                    $this->$cachedLocation = $data[1] instanceof Factory ? $data[1]->create() : $data[1];
+                    $this->$cachedLocation = $relationship->getData() instanceof Factory ? $relationship->getData()->create(
+                    ) : $relationship->getData();
                 }
-                $model->{$relationshipName}()->associate($this->$cachedLocation);
+                $model->{$relationship->getFunctionName()}()->associate($this->$cachedLocation);
             }
         );
 

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -340,13 +340,9 @@ abstract class Factory
      */
     protected function handleWithRelationship(string $functionName, array $arguments)
     {
-        if (!Str::startsWith($functionName, ['with', 'has'])) {
-            return false;
-        }
-
-        $this->addRelationship($this->withRelationships, $functionName, $arguments);
-
-        return true;
+        return Str::startsWith($functionName, ['with', 'has']) ?
+            $this->addRelationship($this->withRelationships, $functionName, $arguments) :
+            false;
     }
 
     /**
@@ -358,13 +354,9 @@ abstract class Factory
      */
     protected function handleForRelationship(string $functionName, array $arguments)
     {
-        if (!Str::startsWith($functionName, 'for')) {
-            return false;
-        }
-
-        $this->addRelationship($this->forRelationships, $functionName, $arguments);
-
-        return true;
+        return Str::startsWith($functionName, 'for') ?
+            $this->addRelationship($this->forRelationships, $functionName, $arguments) :
+            false;
     }
 
     protected function addRelationship(Collection $relationshipArray, string $functionName, array $arguments)
@@ -376,6 +368,8 @@ abstract class Factory
                 $arguments
             )
         ];
+
+        return true;
     }
 
     protected function handleDefaultRelationships()

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -401,7 +401,7 @@ abstract class Factory
                     function ($relationships) use ($relationshipMethodName) {
                         return $relationships->filter(
                             function (Relationship $withRelationship) use ($relationshipMethodName) {
-                                return $withRelationship->getFunctionName() == $relationshipMethodName;
+                                return $withRelationship->getMethodName() == $relationshipMethodName;
                             }
                         )->isNotEmpty();
                     }
@@ -565,7 +565,7 @@ abstract class Factory
                 $models = $relationship->buildModels();
                 $models->each(
                     function ($relatedModel, $index) use ($model, $relationship) {
-                        $model->{$relationship->getFunctionName()}()->save(
+                        $model->{$relationship->getMethodName()}()->save(
                             $relatedModel,
                             $this->getDesiredAttributeData(
                                 isset($relationship->getData()->pivotAttributes) ?
@@ -600,11 +600,11 @@ abstract class Factory
     {
         $this->forRelationships->each(
             function (Relationship $relationship) use ($model) {
-                $cachedLocation = "PoserForRelationship_" . $relationship->getFunctionName();
+                $cachedLocation = "PoserForRelationship_" . $relationship->getMethodName();
                 if (!isset($this->$cachedLocation)) {
                     $this->$cachedLocation = $relationship->createModels();
                 }
-                $model->{$relationship->getFunctionName()}()->associate($this->$cachedLocation);
+                $model->{$relationship->getMethodName()}()->associate($this->$cachedLocation);
             }
         );
 

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -341,7 +341,7 @@ abstract class Factory
     protected function handleWithRelationship(string $functionName, array $arguments)
     {
         return Str::startsWith($functionName, ['with', 'has']) ?
-            $this->addRelationship($this->withRelationships, $functionName, $arguments) :
+            (bool) $this->addRelationship($this->withRelationships, $functionName, $arguments) :
             false;
     }
 
@@ -355,21 +355,19 @@ abstract class Factory
     protected function handleForRelationship(string $functionName, array $arguments)
     {
         return Str::startsWith($functionName, 'for') ?
-            $this->addRelationship($this->forRelationships, $functionName, $arguments) :
+            (bool) $this->addRelationship($this->forRelationships, $functionName, $arguments) :
             false;
     }
 
     protected function addRelationship(Collection $relationshipArray, string $functionName, array $arguments)
     {
-        $relationshipArray[] = [
+        return $relationshipArray->push([
             $this->getRelationshipMethodName($functionName),
             $this->buildRelationshipData(
                 $functionName,
                 $arguments
             )
-        ];
-
-        return true;
+        ]);
     }
 
     protected function handleDefaultRelationships()

--- a/src/Relationship.php
+++ b/src/Relationship.php
@@ -6,7 +6,7 @@ namespace Lukeraymonddowning\Poser;
 
 use ArrayAccess;
 
-class Relationship implements ArrayAccess
+class Relationship
 {
 
     protected $functionName, $data;
@@ -27,56 +27,4 @@ class Relationship implements ArrayAccess
         return $this->data;
     }
 
-    /**
-     * @inheritDoc
-     */
-    public function offsetExists($offset)
-    {
-        return in_array($offset, [0, 1]);
-    }
-
-    /**
-     * @inheritDoc
-     */
-    public function offsetGet($offset)
-    {
-        switch ($offset) {
-            case 0:
-                return $this->getFunctionName();
-            case 1:
-                return $this->getData();
-        }
-
-        return null;
-    }
-
-    /**
-     * @inheritDoc
-     */
-    public function offsetSet($offset, $value)
-    {
-        switch ($offset) {
-            case 0:
-                $this->functionName = $value;
-                break;
-            case 1:
-                $this->data = $value;
-                break;
-        }
-    }
-
-    /**
-     * @inheritDoc
-     */
-    public function offsetUnset($offset)
-    {
-        switch ($offset) {
-            case 0:
-                $this->functionName = null;
-                break;
-            case 1:
-                $this->data = null;
-                break;
-        }
-    }
 }

--- a/src/Relationship.php
+++ b/src/Relationship.php
@@ -1,0 +1,28 @@
+<?php
+
+
+namespace Lukeraymonddowning\Poser;
+
+
+class Relationship
+{
+
+    protected $functionName, $arguments;
+
+    public function __construct(string $functionName, array $arguments)
+    {
+        $this->functionName = $functionName;
+        $this->arguments = $arguments;
+    }
+
+    public function getFunctionName(): string
+    {
+        return $this->functionName;
+    }
+
+    public function getArguments(): array
+    {
+        return $this->arguments;
+    }
+
+}

--- a/src/Relationship.php
+++ b/src/Relationship.php
@@ -8,17 +8,17 @@ use Illuminate\Database\Eloquent\Model;
 class Relationship
 {
 
-    protected $functionName, $data, $models;
+    protected $methodName, $data, $models;
 
-    public function __construct(string $functionName, object $data)
+    public function __construct(string $methodName, object $data)
     {
-        $this->functionName = $functionName;
+        $this->methodName = $methodName;
         $this->data = $data;
     }
 
-    public function getFunctionName(): string
+    public function getMethodName(): string
     {
-        return $this->functionName;
+        return $this->methodName;
     }
 
     public function getData(): object

--- a/src/Relationship.php
+++ b/src/Relationship.php
@@ -4,15 +4,17 @@
 namespace Lukeraymonddowning\Poser;
 
 
-class Relationship
+use ArrayAccess;
+
+class Relationship implements ArrayAccess
 {
 
-    protected $functionName, $arguments;
+    protected $functionName, $data;
 
-    public function __construct(string $functionName, array $arguments)
+    public function __construct(string $functionName, object $data)
     {
         $this->functionName = $functionName;
-        $this->arguments = $arguments;
+        $this->data = $data;
     }
 
     public function getFunctionName(): string
@@ -20,9 +22,61 @@ class Relationship
         return $this->functionName;
     }
 
-    public function getArguments(): array
+    public function getData(): object
     {
-        return $this->arguments;
+        return $this->data;
     }
 
+    /**
+     * @inheritDoc
+     */
+    public function offsetExists($offset)
+    {
+        return in_array($offset, [0, 1]);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function offsetGet($offset)
+    {
+        switch ($offset) {
+            case 0:
+                return $this->getFunctionName();
+            case 1:
+                return $this->getData();
+        }
+
+        return null;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function offsetSet($offset, $value)
+    {
+        switch ($offset) {
+            case 0:
+                $this->functionName = $value;
+                break;
+            case 1:
+                $this->data = $value;
+                break;
+        }
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function offsetUnset($offset)
+    {
+        switch ($offset) {
+            case 0:
+                $this->functionName = null;
+                break;
+            case 1:
+                $this->data = null;
+                break;
+        }
+    }
 }

--- a/src/Relationship.php
+++ b/src/Relationship.php
@@ -3,13 +3,12 @@
 
 namespace Lukeraymonddowning\Poser;
 
-
-use ArrayAccess;
+use Illuminate\Database\Eloquent\Model;
 
 class Relationship
 {
 
-    protected $functionName, $data;
+    protected $functionName, $data, $models;
 
     public function __construct(string $functionName, object $data)
     {
@@ -25,6 +24,25 @@ class Relationship
     public function getData(): object
     {
         return $this->data;
+    }
+
+    public function dataIsFactory()
+    {
+        return $this->data instanceof Factory;
+    }
+
+    public function buildModels()
+    {
+        $builtModels = $this->dataIsFactory() ? $this->getData()->make() : $this->getData();
+
+        return $builtModels instanceof Model ? collect([$builtModels]) : $builtModels;
+    }
+
+    public function createModels()
+    {
+        return $this->dataIsFactory() ?
+            $this->getData()->create() :
+            $this->getData();
     }
 
 }


### PR DESCRIPTION
Previously, we have used a Collection of arrays to handle relationship data. I want to replace this with a class to offer improved readability and simplicity.

I have created a `Relationship` class, which is used when adding any type of relationship to Poser. This Relationship class has a number of helper methods which go a long way to simplify some of the method calls in `Factory` itself.