### PR TITLE
Remove one '/' from '//' in the destination variable.

### DIFF
--- a/src/CreatePoserFactory.php
+++ b/src/CreatePoserFactory.php
@@ -72,7 +72,7 @@ class CreatePoserFactory extends GeneratorCommand
 
         File::ensureDirectoryExists($destinationDirectory);
 
-        $destination = $destinationDirectory . "/" . Str::afterLast($requestedModelWithDirectoryString, "/") . ".php";
+        $destination = rtrim($destinationDirectory, "/") . "/" . Str::afterLast($requestedModelWithDirectoryString, "/") . ".php";
 
         if (File::exists($destination)) {
             $this->error("There is already a Factory called " . $factoryName . " at " . $destinationDirectory);


### PR DESCRIPTION
I was creating pose files and I see this in my terminal log after the file is created

```
UserFactory successfully created at /home/vagrant/code/my-website.test/tests/Factories//UserFactory.php
```

Although the '//' didn't cause an error, I think it'd be cleaner to remove the unnecessary '/'. This commit make sure that there is only one '/', so it'll show cleaner message like this.

```
UserFactory successfully created at /home/vagrant/code/my-website.test/tests/Factories/UserFactory.php
```

I ran `composer test` and everything seems to work as expected.