### PR TITLE
Relationships now support snake case methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
-# 1.0.0
+# 4.0.1
+Adds backwards-compatible support for `snake_case` relationship methods. Poser will check to see if 
+a `snake_case` method exists on the `Model` and call it if so, instead of the default `camelCase`.
+
+# 4.0.0
 The first non-beta release of Poser! I've been using Poser in production for a little while now,
 and I'm happy to recommend you do too!
 

--- a/src/Relationship.php
+++ b/src/Relationship.php
@@ -5,6 +5,8 @@ namespace Lukeraymonddowning\Poser;
 
 
 use ArrayAccess;
+use Illuminate\Support\Str;
+use Illuminate\Database\Eloquent\Model;
 
 class Relationship
 {
@@ -17,8 +19,16 @@ class Relationship
         $this->data = $data;
     }
 
-    public function getFunctionName(): string
+    public function getFunctionName(Model $model = null): string
     {
+        if (!$model) {
+            return $this->functionName;
+        }
+
+        if (method_exists($model, Str::snake($this->functionName))) {
+            return Str::snake($this->functionName);
+        }
+
         return $this->functionName;
     }
 


### PR DESCRIPTION
If a factory has a relationship method that uses `snake_case`, poser can now check it and convert as necessary.