### PR TITLE
Adds the `craft` and `craftOne` methods.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 4.1.0
+Adds support for quick create syntax, by using the `craft` and `craftOne` methods. This allows for a simpler
+syntax when you only need to quickly create a model and don't need to add complex relationship mapping.
+
 # 4.0.1
 Adds backwards-compatible support for `snake_case` relationship methods. Poser will check to see if 
 a `snake_case` method exists on the `Model` and call it if so, instead of the default `camelCase`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 # 4.1.0
-Adds support for quick create syntax, by using the `craft` and `craftOne` methods. This allows for a simpler
+Adds support for quick create syntax, by using the `craft` method. This allows for a simpler
 syntax when you only need to quickly create a model and don't need to add complex relationship mapping.
 
 # 4.0.1

--- a/README.md
+++ b/README.md
@@ -599,8 +599,8 @@ Allows you to create multiple models, persist them to the database, and return t
 method call. A very useful shortcut when you don't need complex relationship mapping. You may pass in the count of
 models you wish to create, along with attributes that should be given to those models.
 
-#### `::craftOne(array $attributes = null)`
-Similar to `::craft`, but for a single model instance. It will return the model instead of a collection.
+#### `::craft(array $attributes = null)`
+If you only need to craft one model, you can omit the count. It will return the model instead of a collection.
 
 #### `->create(...$attributes)` or `(...$attributes)`
 Similar to the Laravel factory `create` command, this will create the models, persisting them to the database.

--- a/README.md
+++ b/README.md
@@ -599,8 +599,11 @@ Allows you to create multiple models, persist them to the database, and return t
 method call. A very useful shortcut when you don't need complex relationship mapping. You may pass in the count of
 models you wish to create, along with attributes that should be given to those models.
 
+#### `::craft(...$attributes, int $count)`
+Alternate syntax for `craft` as described above, which more closely matches `factory` method baked into Laravel.
+
 #### `::craft(array $attributes = null)`
-If you only need to craft one model, you can omit the count. It will return the model instead of a collection.
+If you only need to craft one model, you can omit the count. It will return a single model instead of a collection.
 
 #### `->create(...$attributes)` or `(...$attributes)`
 Similar to the Laravel factory `create` command, this will create the models, persisting them to the database.

--- a/README.md
+++ b/README.md
@@ -594,6 +594,14 @@ instead call the relationship method statically, like so: `UserFactory::withCust
 Creates a new instance of the factory, but informs the factory that you will be creating multiple models.
 Use this to instantiate the class when you wish to create multiple entries in the database.
 
+#### `::craft(int $count, ...$attributes)`
+Allows you to create multiple models, persist them to the database, and return the resulting collection, all in one
+method call. A very useful shortcut when you don't need complex relationship mapping. You may pass in the count of
+models you wish to create, along with attributes that should be given to those models.
+
+#### `::craftOne(array $attributes = null)`
+Similar to `::craft`, but for a single model instance. It will return the model instead of a collection.
+
 #### `->create(...$attributes)` or `(...$attributes)`
 Similar to the Laravel factory `create` command, this will create the models, persisting them to the database.
 You may pass an associative array of column names with desired values, which will be applied to the 

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -68,8 +68,9 @@ abstract class Factory
      * For those times where you don't need super complex relationship mapping, and just want to quickly build a model
      * or collection of models.
      *
-     * @param mixed ...$parameters If you need to build multiple models, the first parameter should be desired count,
-     * with any other parameters forming your attribute sets. If you're building a single model, you may omit the count.
+     * @param mixed ...$parameters If you need to build multiple models, the first or last parameter should be the
+     * desired count, with any other parameters forming your attribute sets.
+     * If you're building a single model, you may omit the count.
      *
      * @return \Illuminate\Database\Eloquent\Collection|Model|Model[]|Collection
      */
@@ -77,8 +78,16 @@ abstract class Factory
     {
         $factory = self::new();
 
-        if (!empty($parameters) && is_int($parameters[0])) {
+        if (empty($parameters)) {
+            return $factory->create();
+        }
+
+        if (is_int($parameters[0])) {
             $factory->count = Arr::pull($parameters, 0);
+        }
+
+        if (is_int(Arr::last($parameters))) {
+            $factory->count = Arr::pull($parameters, count($parameters) - 1);
         }
 
         $factory->withAttributes(...$parameters);

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -63,6 +63,34 @@ abstract class Factory
         return $factory;
     }
 
+    /**
+     * Immediately builds, persists and returns a model of the Factory type,
+     * optionally with the given parameters.
+     *
+     * @param array $attributes
+     * @return Model
+     */
+    public static function craftOne(array $attributes = [])
+    {
+        return self::craft(1, $attributes);
+    }
+
+    /**
+     * Immediately builds, persists an returns the number of requested models
+     * of the Factory type, optionally with the given parameters or parameter sets.
+     *
+     * @param int   $count
+     * @param mixed ...$attributes
+     * @return \Illuminate\Database\Eloquent\Collection|Model|Model[]|Collection
+     */
+    public static function craft(int $count, ...$attributes)
+    {
+        $factory = self::times($count);
+        $factory->withAttributes(...$attributes);
+
+        return $factory->create();
+    }
+
     public function __construct()
     {
         $this->testCaseCaller = new TestCaseCaller();


### PR DESCRIPTION
I've been using Poser extensively in a big project, and using it to create all models, not just complex ones. Often, I just want to quickly build a model or collection or models and return the result.

This PR adds the `::craft` and `::craftOne` static methods, which can be used instead of `::new` or `::times` to do exactly as described above. You may pass in attributes to the methods, and they  will be used as you'd expect. This is basically short hand for `XyzFactory::new()->withAttributes(['name' => 'value'])->create()`. The previous statement could now be rewritten as `XyzFactory::craft(['name' => 'value])`.